### PR TITLE
feat(.github): add CARTO features manifest CI verification

### DIFF
--- a/.github/carto-features.yml
+++ b/.github/carto-features.yml
@@ -46,7 +46,7 @@ features:
     files:
       - litellm/llms/azure/common_utils.py
     verification:
-      - pattern: "re.sub.*chat/completions"
+      - pattern: "chat/completions|completions|embeddings|audio/speech"
         file: litellm/llms/azure/common_utils.py
 
   - name: "JSON Repair for Streaming Tool Calls"

--- a/.github/workflows/carto-features-check.yml
+++ b/.github/workflows/carto-features-check.yml
@@ -1,0 +1,64 @@
+name: CARTO Features Manifest Check
+
+on:
+  push:
+    branches:
+      - 'upstream-sync/**'
+  pull_request:
+    branches:
+      - 'carto/main'
+
+jobs:
+  verify-manifest:
+    name: Verify CARTO Features
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check manifest exists
+        id: check-manifest
+        run: |
+          if [ ! -f .github/carto-features.yml ]; then
+            echo "::notice::carto-features.yml not found - skipping verification"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          else
+            echo "exists=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Verify manifest patterns
+        if: steps.check-manifest.outputs.exists == 'true'
+        run: |
+          echo "::group::Verifying CARTO features manifest patterns"
+
+          python3 -c "
+          import yaml, subprocess, sys
+
+          with open('.github/carto-features.yml') as f:
+              data = yaml.safe_load(f)
+
+          total = 0
+          missing = []
+
+          for feat in data.get('features', []):
+              for v in feat.get('verification', []):
+                  total += 1
+                  r = subprocess.run(['grep', '-q', v['pattern'], v['file']], capture_output=True)
+                  if r.returncode == 0:
+                      print(f'✅ {feat[\"name\"]} - {v[\"pattern\"]} in {v[\"file\"]}')
+                  else:
+                      print(f'❌ {feat[\"name\"]} - {v[\"pattern\"]} in {v[\"file\"]}')
+                      missing.append(f'{feat[\"name\"]}: {v[\"pattern\"]} in {v[\"file\"]}')
+
+          print(f'\n--- Results: {total - len(missing)}/{total} patterns verified ---')
+
+          if missing:
+              print(f'\n{len(missing)} MISSING pattern(s):')
+              for m in missing:
+                  print(f'  - {m}')
+              sys.exit(1)
+          else:
+              print('\nAll CARTO feature patterns verified.')
+          "
+
+          echo "::endgroup::"

--- a/.github/workflows/carto-upstream-sync-ci-fixer.yml
+++ b/.github/workflows/carto-upstream-sync-ci-fixer.yml
@@ -421,6 +421,18 @@ jobs:
 
             ---
 
+            ## CARTO FEATURES MANIFEST
+
+            Before making ANY changes, read the features manifest:
+            ```bash
+            cat .github/carto-features.yml 2>/dev/null || echo "No manifest found"
+            ```
+
+            These patterns MUST still exist after your fixes. If a fix would remove a
+            pattern, find an alternative approach that preserves the CARTO feature.
+
+            ---
+
             ## STEP 0: FIX LOOP DETECTION (DO THIS FIRST!)
 
             Check for fix loops before doing anything:

--- a/.github/workflows/carto-upstream-sync-resolver.yml
+++ b/.github/workflows/carto-upstream-sync-resolver.yml
@@ -789,6 +789,41 @@ jobs:
 
             ---
 
+            ## CARTO FEATURES MANIFEST (CRITICAL)
+
+            The features manifest lists EXACT patterns that MUST exist after resolution.
+            Read it and verify all patterns survive:
+
+            ```bash
+            cat .github/carto-features.yml
+            ```
+
+            After resolving ALL conflicts, verify each pattern:
+            ```bash
+            python3 -c "
+            import yaml, subprocess, sys
+            with open('.github/carto-features.yml') as f:
+                data = yaml.safe_load(f)
+            missing = 0
+            for feat in data.get('features', []):
+                for v in feat.get('verification', []):
+                    r = subprocess.run(['grep', '-q', v['pattern'], v['file']], capture_output=True)
+                    status = 'OK' if r.returncode == 0 else 'MISSING'
+                    print(f'{status}: {feat[\"name\"]} - {v[\"pattern\"]} in {v[\"file\"]}')
+                    if r.returncode != 0:
+                        missing += 1
+            if missing:
+                print(f'\nWARNING: {missing} pattern(s) missing!')
+                sys.exit(1)
+            else:
+                print('\nAll CARTO feature patterns verified.')
+            "
+            ```
+
+            If ANY patterns are MISSING, restore them from carto/main or re-implement.
+
+            ---
+
             ## SYNC-REQUIRED FILES (Always Accept Upstream TAG)
 
             These files MUST match upstream regardless of CARTO history:
@@ -1111,6 +1146,41 @@ jobs:
 
           echo "✅ No conflict markers found"
           echo "resolved=true" >> $GITHUB_OUTPUT
+          echo "::endgroup::"
+
+      - name: Verify CARTO features manifest
+        id: verify-manifest
+        if: steps.verify-resolution.outputs.resolved == 'true'
+        run: |
+          echo "::group::Verifying CARTO features manifest patterns"
+
+          if [ ! -f .github/carto-features.yml ]; then
+            echo "::notice::carto-features.yml not found - skipping manifest verification"
+            echo "::endgroup::"
+            exit 0
+          fi
+
+          python3 -c "
+          import yaml, subprocess
+          with open('.github/carto-features.yml') as f:
+              data = yaml.safe_load(f)
+          missing = []
+          for feat in data.get('features', []):
+              for v in feat.get('verification', []):
+                  r = subprocess.run(['grep', '-q', v['pattern'], v['file']], capture_output=True)
+                  if r.returncode == 0:
+                      print(f'OK: {feat[\"name\"]} - {v[\"pattern\"]} in {v[\"file\"]}')
+                  else:
+                      print(f'MISSING: {feat[\"name\"]} - {v[\"pattern\"]} in {v[\"file\"]}')
+                      missing.append(f'{feat[\"name\"]}: {v[\"pattern\"]} in {v[\"file\"]}')
+          if missing:
+              print(f'\n::warning::CARTO features manifest: {len(missing)} pattern(s) missing (Claude may have intentionally changed code):')
+              for m in missing:
+                  print(f'  - {m}')
+          else:
+              print('\nAll CARTO feature patterns verified.')
+          "
+
           echo "::endgroup::"
 
       - name: Complete merge commit (HARDCODED - creates merge with both parents)


### PR DESCRIPTION
## Summary

- Adds standalone `carto-features-check.yml` workflow that verifies all manifest patterns on `upstream-sync/**` pushes and PRs to `carto/main`
- Adds manifest awareness to resolver and CI fixer Claude prompts so they preserve CARTO patches during upstream syncs
- Adds a manifest verification step in the resolver workflow between conflict check and merge commit
- Fixes Azure URL Suffix Stripping pattern to work with single-line grep

## Details

The features manifest (`.github/carto-features.yml`) lists grep-verifiable patterns for all CARTO-specific customizations. This PR wires it into CI so patterns are automatically checked, preventing accidental loss of CARTO patches during upstream merges.

9/10 patterns pass on `carto/main` — the missing one (Snowflake Full URL Passthrough) will arrive when `upstream-sync/v1.81.0-stable` merges.

## Shortcut

https://app.shortcut.com/cartoteam/story/536230

## Test plan

- [ ] Verify `carto-features-check` workflow triggers on this PR
- [ ] Verify 9/10 patterns pass (Snowflake Full URL Passthrough expected missing until upstream-sync merges)
- [ ] Verify resolver workflow YAML is valid
- [ ] Verify CI fixer workflow YAML is valid