### PR TITLE
chore: cleanup Slack notifications — remove redundant titles, migrate release to Block Kit

### DIFF
--- a/.github/workflows/carto-release.yaml
+++ b/.github/workflows/carto-release.yaml
@@ -619,68 +619,106 @@ jobs:
           esac
 
           # Extract key highlights from release notes (first 3 bullet points from Features/Fixes sections)
-          HIGHLIGHTS=""
+          HIGHLIGHTS_TEXT=""
           if [ -f "release_notes.md" ]; then
-            # Get CARTO-specific features and fixes (limit to 3 most important)
             FEATURES=$(grep -A 5 "### ✨" release_notes.md 2>/dev/null | grep "^-" | head -2 | sed 's/^- /• /' || echo "")
             FIXES=$(grep -A 5 "### 🐛" release_notes.md 2>/dev/null | grep "^-" | head -1 | sed 's/^- /• /' || echo "")
 
             if [ -n "$FEATURES" ] || [ -n "$FIXES" ]; then
-              HIGHLIGHTS=$'\n\n*Key Highlights:*\n'
-              [ -n "$FEATURES" ] && HIGHLIGHTS+="${FEATURES}"$'\n'
-              [ -n "$FIXES" ] && HIGHLIGHTS+="${FIXES}"
+              HIGHLIGHTS_TEXT="\n*Key Highlights:*\n"
+              [ -n "$FEATURES" ] && HIGHLIGHTS_TEXT+="${FEATURES}\n"
+              [ -n "$FIXES" ] && HIGHLIGHTS_TEXT+="${FIXES}"
             fi
           fi
 
-          # Build concise Slack message
-          MESSAGE="━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-          ${EMOJI} *LiteLLM CARTO Release* \`${RELEASE_TAG}\`
-          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-          :label: *Type:* ${TYPE_LABEL}${VERSION_CHANGE:+ ($VERSION_CHANGE)}
-          :package: *CARTO Version:* ${CARTO_VERSION}
-          :gear: *Upstream Base:* LiteLLM v${UPSTREAM_VERSION}${HIGHLIGHTS}
-
-          :link: <${RELEASE_URL}|View Release Notes>
-          :whale: \`${DOCKER_IMAGE}\`"
+          # Determine color based on release type
+          case "$RELEASE_TYPE" in
+            upstream_sync) RELEASE_COLOR="#1E88E5" ;;
+            feature) RELEASE_COLOR="#36a64f" ;;
+            patch) RELEASE_COLOR="#FFA500" ;;
+            *) RELEASE_COLOR="#808080" ;;
+          esac
 
           echo "[Slack] Sending notification to channel ${SLACK_CHANNEL}"
           echo "::endgroup::"
 
           echo "::group::Posting to Slack"
 
+          # Build Block Kit payload
+          cat > /tmp/slack_payload.json << EOF
+          {
+            "channel": "${SLACK_CHANNEL}",
+            "attachments": [
+              {
+                "color": "${RELEASE_COLOR}",
+                "fallback": "${EMOJI} LiteLLM CARTO Release ${RELEASE_TAG}",
+                "blocks": [
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*${EMOJI} LiteLLM CARTO Release* — \`${RELEASE_TAG}\`\n${TYPE_LABEL}${VERSION_CHANGE:+ ($VERSION_CHANGE)}${HIGHLIGHTS_TEXT}"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "fields": [
+                      { "type": "mrkdwn", "text": "*CARTO Version:*\n${CARTO_VERSION}" },
+                      { "type": "mrkdwn", "text": "*Upstream Base:*\nv${UPSTREAM_VERSION}" }
+                    ]
+                  },
+                  {
+                    "type": "context",
+                    "elements": [
+                      { "type": "mrkdwn", "text": ":whale: \`${DOCKER_IMAGE}\`" }
+                    ]
+                  },
+                  {
+                    "type": "actions",
+                    "elements": [
+                      {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "View Release", "emoji": true },
+                        "style": "primary",
+                        "url": "${RELEASE_URL}"
+                      },
+                      {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "View Logs", "emoji": true },
+                        "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+
+          # Validate JSON
+          if ! jq empty /tmp/slack_payload.json 2>/dev/null; then
+            echo "::error::Invalid JSON payload"
+            cat /tmp/slack_payload.json
+            exit 1
+          fi
+
           # Retry logic (up to 3 attempts)
           SUCCESS=false
           for attempt in 1 2 3; do
             echo "[Slack] Attempt ${attempt}/3..."
 
-            # Send to Slack API
-            RESPONSE=$(curl -s -w "\n%{http_code}" \
-              -F "text=${MESSAGE}" \
-              -F "channel=${SLACK_CHANNEL}" \
+            RESPONSE=$(curl -s -X POST https://slack.com/api/chat.postMessage \
               -H "Authorization: Bearer ${{ secrets.SLACK_KEY }}" \
-              -X POST https://slack.com/api/chat.postMessage)
+              -H "Content-Type: application/json" \
+              -d @/tmp/slack_payload.json)
 
-            # Extract HTTP code and body
-            HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-            BODY=$(echo "$RESPONSE" | head -n-1)
-
-            echo "[Slack] HTTP ${HTTP_CODE}"
-            echo "[Slack] Response: ${BODY}"
-
-            # Check if successful
-            if [ "$HTTP_CODE" = "200" ]; then
-              # Check Slack API response
-              if echo "$BODY" | grep -q '"ok":true'; then
-                echo "✅ [Slack] Release notification sent successfully"
-                SUCCESS=true
-                break
-              else
-                ERROR=$(echo "$BODY" | grep -o '"error":"[^"]*"' || echo "unknown error")
-                echo "⚠️ [Slack] Slack API error: ${ERROR}"
-              fi
+            if echo "$RESPONSE" | jq -e '.ok == true' > /dev/null 2>&1; then
+              echo "✅ [Slack] Release notification sent successfully"
+              SUCCESS=true
+              break
             else
-              echo "⚠️ [Slack] HTTP error: ${HTTP_CODE}"
+              ERROR=$(echo "$RESPONSE" | jq -r '.error // "unknown"')
+              echo "⚠️ [Slack] Slack API error: ${ERROR}"
             fi
 
             # Wait before retry

--- a/.github/workflows/carto-slack-changelog.yml
+++ b/.github/workflows/carto-slack-changelog.yml
@@ -219,24 +219,16 @@ jobs:
           cat > /tmp/slack_payload.json << EOF
           {
             "channel": "${{ env.SLACK_CHANNEL }}",
-            "text": "${EMOJI} ${TYPE}: ${TITLE_ESCAPED}",
             "attachments": [
               {
                 "color": "${COLOR}",
+                "fallback": "${EMOJI} ${TYPE}: ${TITLE_ESCAPED}",
                 "blocks": [
-                  {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "${EMOJI} ${TYPE}: PR #${PR_NUM}",
-                      "emoji": true
-                    }
-                  },
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*${TITLE_ESCAPED}*"
+                      "text": "*${EMOJI} ${TYPE}:* PR #${PR_NUM} — ${TITLE_ESCAPED}"
                     }
                   },
                   {
@@ -330,24 +322,16 @@ jobs:
           cat > /tmp/slack_payload.json << EOF
           {
             "channel": "${{ env.SLACK_CHANNEL }}",
-            "text": "${EMOJI} ${TYPE}: ${TAG}",
             "attachments": [
               {
                 "color": "${COLOR}",
+                "fallback": "${EMOJI} ${TYPE}: ${TAG}",
                 "blocks": [
-                  {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": "${EMOJI} ${TYPE}: ${TAG}",
-                      "emoji": true
-                    }
-                  },
                   {
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "*${NAME_ESCAPED}*"
+                      "text": "*${EMOJI} ${TYPE}:* ${TAG} — ${NAME_ESCAPED}"
                     }
                   },
                   {

--- a/.github/workflows/carto-upstream-sync-main.yml
+++ b/.github/workflows/carto-upstream-sync-main.yml
@@ -816,23 +816,22 @@ jobs:
                       }'
           fi
 
-          # Build improved Block Kit payload with colored sidebar and better visual hierarchy
+          # Build Block Kit payload with colored sidebar
           cat > /tmp/slack_payload.json << EOF
           {
             "channel": "${SLACK_CHANNEL_LITELLM}",
-            "text": "${TITLE}: ${STEP_TEXT}",
             "unfurl_links": false,
             "unfurl_media": false,
             "attachments": [
               {
                 "color": "${COLOR}",
+                "fallback": "${TITLE}: ${STEP_TEXT}",
                 "blocks": [
                   {
-                    "type": "header",
+                    "type": "section",
                     "text": {
-                      "type": "plain_text",
-                      "text": "${STEP_EMOJI} ${TITLE}",
-                      "emoji": true
+                      "type": "mrkdwn",
+                      "text": "*${STEP_EMOJI} ${TITLE}*"
                     }
                   },
                   {

--- a/.github/workflows/carto-upstream-sync-ready-checker.yml
+++ b/.github/workflows/carto-upstream-sync-ready-checker.yml
@@ -186,24 +186,23 @@ jobs:
           # Build compare URL for upstream changes
           COMPARE_URL="https://github.com/BerriAI/litellm/releases/tag/${VERSION}"
 
-          # Build improved Block Kit payload with colored sidebar
+          # Build Block Kit payload with colored sidebar
           cat > /tmp/slack_payload.json << EOF
           {
             "channel": "${SLACK_CHANNEL_LITELLM}",
             ${THREAD_PARAM}
-            "text": "✅ LiteLLM Upstream Sync: Tests Passed",
             "unfurl_links": false,
             "unfurl_media": false,
             "attachments": [
               {
                 "color": "#1E88E5",
+                "fallback": "LiteLLM Upstream Sync: Tests Passed (v${VERSION_CLEAN})",
                 "blocks": [
                   {
-                    "type": "header",
+                    "type": "section",
                     "text": {
-                      "type": "plain_text",
-                      "text": "✅ LiteLLM Upstream Sync",
-                      "emoji": true
+                      "type": "mrkdwn",
+                      "text": "*:white_check_mark: LiteLLM Upstream Sync*"
                     }
                   },
                   {
@@ -211,7 +210,7 @@ jobs:
                     "elements": [
                       {
                         "type": "mrkdwn",
-                        "text": "${PROGRESS}  *Step 4 of 4: Tests Passed*"
+                        "text": "${PROGRESS}  *Step 4/4: Tests Passed*"
                       }
                     ]
                   },
@@ -219,11 +218,8 @@ jobs:
                     "type": "section",
                     "text": {
                       "type": "mrkdwn",
-                      "text": "All CI checks completed successfully. PR is ready for review and merge."
+                      "text": "All CI checks passed. PR ready for review and merge."
                     }
-                  },
-                  {
-                    "type": "divider"
                   },
                   {
                     "type": "section",
@@ -235,15 +231,6 @@ jobs:
                       {
                         "type": "mrkdwn",
                         "text": "*Status*\n:white_check_mark: Ready to merge"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "context",
-                    "elements": [
-                      {
-                        "type": "mrkdwn",
-                        "text": ":arrow_right: Review changes and merge to deploy the update."
                       }
                     ]
                   },


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/538271
- Autolink: [sc-538271]

Cleanup Slack notifications across all CARTO workflow files. This is the litellm-fork counterpart to CartoDB/cloud-native#23436.

## Changes

### 1. Remove redundant title (4 notifications)
All Block Kit notifications had a top-level `"text"` field alongside `"attachments"`. Slack renders `"text"` as plain text ABOVE the colored sidebar, duplicating the header inside the block. Fixed by removing `"text"` and using the attachment-level `"fallback"` field (notification preview only, not rendered in channel).

**Affected files:**
- `carto-upstream-sync-main.yml` — upstream sync status (Steps 1-2)
- `carto-upstream-sync-ready-checker.yml` — tests passed (Step 4)
- `carto-slack-changelog.yml` — PR merge + release changelog

### 2. Conciseness improvements
- Removed `header` blocks, replaced with bold mrkdwn in `section` blocks
- Removed `divider` blocks and redundant context blocks
- Folded title/type info into single section line

### 3. Migrate carto-release.yaml to Block Kit
The release notification was the last remaining old-format notification using plain text via `-F "text=..."` with Unicode box-drawing separators. Migrated to Block Kit with:
- Colored sidebar (blue for upstream sync, green for feature, orange for patch)
- Structured fields (CARTO Version, Upstream Base)
- Action buttons (View Release, View Logs)
- JSON validation before sending
- Switched from form-encoded to JSON POST

## Type of change

- [x] Chore

## Acceptance

1. Create a CARTO release and verify the Slack notification in #cartodb-ops uses Block Kit with colored sidebar instead of plain text with Unicode separators
2. Trigger an upstream sync and verify notifications in #litellm-fork have no redundant title above the colored block
3. Merge a PR to carto/main and verify the changelog notification has no redundant title

## Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Just one issue per PR
- [ ] GitHub labels
- [ ] Proper status & reviewers
- [ ] Tests
- [x] Documentation