### PR TITLE
fix(gh-workflows): grant Write tool to Claude for release notes generation

### DIFF
--- a/.github/workflows/carto-release.yaml
+++ b/.github/workflows/carto-release.yaml
@@ -28,9 +28,9 @@ name: CARTO - Create Release
 #
 # Security measures:
 # - Actor authorization check (Cartofante, mateo-di only)
-# - Read-only tools for Claude (Bash, Read, Grep, Glob)
+# - Scoped tools for Claude (Read, Write, Bash, Grep, Glob) — Write needed for release_notes.md
 # - Rate limiting: max-turns: 50, 20-min timeout (~$0.50-2 per release)
-# - No write access to repository during notes generation
+# - No git push from notes generation step (ephemeral runner)
 #
 # Uses X_GITHUB_SUPERCARTOFANTE token where workflow modifications are needed.
 
@@ -286,7 +286,7 @@ jobs:
           use_vertex: "true"
           github_token: ${{ secrets.GITHUB_TOKEN }}
           show_full_output: false
-          claude_args: "--model claude-sonnet-4-5@20250929 --max-turns 50 --allowedTools Read,Bash,Grep,Glob"
+          claude_args: "--model claude-sonnet-4-5@20250929 --max-turns 50 --allowedTools Read,Write,Bash,Grep,Glob"
           prompt: |
             # Intelligent Release Notes Generation with Upstream Sync Detection
 
@@ -502,21 +502,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         timeout-minutes: 20
 
-      - name: Ensure release_notes.md exists
+      - name: Verify release_notes.md exists
         if: steps.manual-notes.outputs.notes_generated != 'true'
-        env:
-          CLAUDE_OUTPUT: ${{ steps.release-notes.outputs.result }}
         run: |
-          # Claude Code Action may write files inside a sandbox that doesn't
-          # persist on the runner filesystem. If the file is missing, extract
-          # the release notes from the action's output.
+          # Claude writes release_notes.md directly via the Write tool.
+          # NOTE: outputs.result does not exist in claude-code-action@v1
+          # (it was a v0 API). The Write tool is the reliable mechanism.
           if [ -f "release_notes.md" ] && [ -s "release_notes.md" ]; then
-            echo "✅ release_notes.md exists (written directly by Claude)"
-          elif [ -n "$CLAUDE_OUTPUT" ]; then
-            echo "⚠️ release_notes.md not found on disk — writing from Claude output"
-            printf '%s\n' "$CLAUDE_OUTPUT" > release_notes.md
+            echo "✅ release_notes.md exists"
           else
-            echo "::error::Claude step produced no output and release_notes.md is missing"
+            echo "::error::release_notes.md is missing or empty — Claude failed to write it"
             exit 1
           fi
 
@@ -566,7 +561,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### 🔒 Security" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Actor authorization verified" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Claude Code used read-only tools" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Claude Code used scoped tools (no git push)" >> $GITHUB_STEP_SUMMARY
           echo "- ✅ Rate limited (max 50 turns, 20-min timeout)" >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack of new release


### PR DESCRIPTION
## Summary
Fix release workflow failure where Claude couldn't write `release_notes.md` due to missing Write tool permission, and the fallback used a v0 API (`outputs.result`) that doesn't exist in `claude-code-action@v1`.

Fixes: https://github.com/CartoDB/litellm/actions/runs/22917772539/job/66510963426

## What Changed
**Modified:**
- `.github/workflows/carto-release.yaml` — 3 changes:
  1. Added `Write` to `--allowedTools` so Claude can write `release_notes.md` directly
  2. Removed dead v0 fallback code (`outputs.result` doesn't exist in `@v1`)
  3. Updated security comments to reflect scoped tools (Write is safe — ephemeral runner, no git push)

**Removed:**
- Dead `CLAUDE_OUTPUT` / `outputs.result` fallback path (never worked in v1)

## Root Cause Analysis
Two independent failures caused the release workflow to fail:

1. **Write tool denied**: `--allowedTools Read,Bash,Grep,Glob` excluded `Write`. Claude tried to use it, got `permission_denials_count: 1`, and couldn't write `release_notes.md`
2. **Fallback was dead code**: The fallback step used `${{ steps.release-notes.outputs.result }}` which is a v0 API. In `claude-code-action@v1`, this output doesn't exist — it's always empty. The correct v1 outputs are: `execution_file`, `branch_name`, `github_token`, `structured_output`, `session_id`

The previous fix attempt (`0900eac8`) added the fallback logic but didn't address either root cause.

## Architectural Context
EAD: N/A - small change

**Architectural Decisions Made:**
- `Write` is safe to grant: Claude already has `Bash` (which can do everything `Write` can), the runner is ephemeral, and no git push happens from the notes generation step
- Removed the `outputs.result` fallback entirely rather than migrating to `structured_output` with `--json-schema` — simpler and sufficient for this use case

## Review Focus Areas
**Critical areas:**
1. `.github/workflows/carto-release.yaml:289` — verify `Write` is in the correct position in `--allowedTools`

**Safe to skip:** Comment updates (L31, L33, L569)

## Deployment Impact
- [x] Not applicable (docs, tests only)

## Migration & Breaking Changes
- [x] No migrations or breaking changes

## Security Considerations
- [x] No security impact — Write tool is scoped to workspace on ephemeral CI runner

## Performance Impact
- [x] No performance impact

## Tests
- [x] No tests needed — CI workflow change, validated by re-running the release workflow

## Dependencies
- None

## How to Validate
1. Merge this PR
2. Trigger the "CARTO - Create Release" workflow via `workflow_dispatch`
3. Verify the "Verify release_notes.md exists" step passes

## AI-Generated Code Notice
- [x] This PR contains AI-generated code
- [x] Areas requiring extra verification: workflow YAML changes only, minimal risk

## Checklist
- [x] PR title follows convention
- [x] One issue per PR
- [x] AI review findings addressed (if applicable)