### PR TITLE
fix(gh-workflows): handle tree-level merge conflicts in upstream sync

### DIFF
--- a/.github/workflows/carto-upstream-sync-main.yml
+++ b/.github/workflows/carto-upstream-sync-main.yml
@@ -159,46 +159,69 @@ jobs:
           # database tables not present in the stable release schema.
           echo "[Sync] Merging tag ${NEW_VERSION} with -X theirs strategy (preserves commit history)..."
 
-          # Use merge strategy that accepts all upstream changes on conflict
-          # This preserves the full commit history with original SHAs
+          # Attempt merge - capture exit code with || to prevent set -e from killing
+          # the script before the fallback logic can run.
+          # -X theirs resolves content-level conflicts (both sides modified same lines)
+          # but CANNOT resolve tree-level conflicts (rename/rename, modify/delete, rename/delete).
+          MERGE_RESULT=0
           git merge "${NEW_VERSION}" --no-edit -X theirs -m "sync: merge ${NEW_VERSION} tag
 
           Automatic sync from upstream BerriAI/litellm tag ${NEW_VERSION}
 
-          Strategy: Merge with history preservation (main syncs to stable tag)"
+          Strategy: Merge with history preservation (main syncs to stable tag)" || MERGE_RESULT=$?
 
-          if [ $? -eq 0 ]; then
+          if [ $MERGE_RESULT -eq 0 ]; then
             echo "[Sync] ✅ Merge successful with preserved history"
           else
-            # If -X theirs still has conflicts, use more aggressive approach
-            echo "[Sync] ⚠️ Conflicts detected, resolving by accepting all upstream changes..."
+            # Tree-level conflicts (rename/rename, modify/delete, rename/delete) need
+            # explicit resolution. These commonly occur in litellm/proxy/_experimental/out/
+            # where Next.js build artifacts have hashed filenames that change between builds.
+            echo "[Sync] ⚠️ Merge had tree-level conflicts, resolving by accepting upstream..."
 
-            # Get list of conflicted files
-            CONFLICTS=$(git diff --name-only --diff-filter=U)
+            # Detect ALL unmerged paths using git ls-files --unmerged.
+            # Unlike 'git diff --diff-filter=U', this captures every conflict type:
+            #   - content conflicts (both sides modified same lines)
+            #   - modify/delete  (modified on one side, deleted on the other)
+            #   - rename/rename  (renamed differently on both sides)
+            #   - rename/delete  (renamed on one side, deleted on the other)
+            UNMERGED_FILES=$(git ls-files --unmerged | awk '{print $4}' | sort -u)
 
-            if [ -n "$CONFLICTS" ]; then
-              echo "[Sync] Resolving conflicts in files:"
-              echo "$CONFLICTS"
+            if [ -z "$UNMERGED_FILES" ]; then
+              echo "[Sync] ❌ Merge failed with no unmerged files detected - unexpected error"
+              exit 1
+            fi
 
-              # For each conflicted file, accept upstream version
-              echo "$CONFLICTS" | while read -r file; do
-                echo "  - Accepting upstream version of: $file"
-                git checkout --theirs "$file"
-                git add "$file"
-              done
+            CONFLICT_COUNT=$(echo "$UNMERGED_FILES" | wc -l | tr -d ' ')
+            echo "[Sync] Found ${CONFLICT_COUNT} conflicted paths:"
+            echo "$UNMERGED_FILES" | head -20
+            [ "$CONFLICT_COUNT" -gt 20 ] && echo "  ... and $((CONFLICT_COUNT - 20)) more"
 
-              # Complete the merge commit
-              git commit --no-edit -m "sync: merge ${NEW_VERSION} tag
+            # Resolve each conflict by accepting upstream (MERGE_HEAD) version.
+            # For each path: if it exists in the upstream tag, use their version;
+            # if it was deleted in the upstream tag, remove it from our tree.
+            echo "$UNMERGED_FILES" | while read -r file; do
+              if git cat-file -e "MERGE_HEAD:${file}" 2>/dev/null; then
+                echo "  - Accepting upstream: ${file}"
+                git checkout MERGE_HEAD -- "${file}" 2>/dev/null || true
+              else
+                echo "  - Removing (deleted upstream): ${file}"
+                git rm -f "${file}" 2>/dev/null || true
+              fi
+            done
+
+            # Stage any remaining unstaged changes (e.g., orphaned files from
+            # rename/rename conflicts where HEAD's rename destination must be cleaned up)
+            git add -A
+
+            # Complete the merge commit
+            git commit --no-edit -m "sync: merge ${NEW_VERSION} tag
 
           Automatic sync from upstream BerriAI/litellm tag ${NEW_VERSION}
 
-          Strategy: Merge with manual conflict resolution (accepted all tag changes)"
+          Strategy: Merge with tree-level conflict resolution (accepted all upstream changes)
+          Conflicts resolved: ${CONFLICT_COUNT} files"
 
-              echo "[Sync] ✅ Conflicts resolved, merge completed with preserved history"
-            else
-              echo "[Sync] ❌ Merge failed with no conflicts detected - manual intervention needed"
-              exit 1
-            fi
+            echo "[Sync] ✅ Tree-level conflicts resolved, merge completed with preserved history"
           fi
 
           # Push to origin/main (should always be fast-forward with proper merge)

--- a/.github/workflows/carto-upstream-sync-main.yml
+++ b/.github/workflows/carto-upstream-sync-main.yml
@@ -159,16 +159,19 @@ jobs:
           # database tables not present in the stable release schema.
           echo "[Sync] Merging tag ${NEW_VERSION} with -X theirs strategy (preserves commit history)..."
 
-          # Attempt merge - capture exit code with || to prevent set -e from killing
-          # the script before the fallback logic can run.
+          # Attempt merge - capture output and exit code.
+          # The || prevents set -e from killing the script before fallback runs.
           # -X theirs resolves content-level conflicts (both sides modified same lines)
           # but CANNOT resolve tree-level conflicts (rename/rename, modify/delete, rename/delete).
           MERGE_RESULT=0
-          git merge "${NEW_VERSION}" --no-edit -X theirs -m "sync: merge ${NEW_VERSION} tag
+          MERGE_OUTPUT=$(git merge "${NEW_VERSION}" --no-edit -X theirs -m "sync: merge ${NEW_VERSION} tag
 
           Automatic sync from upstream BerriAI/litellm tag ${NEW_VERSION}
 
-          Strategy: Merge with history preservation (main syncs to stable tag)" || MERGE_RESULT=$?
+          Strategy: Merge with history preservation (main syncs to stable tag)" 2>&1) || MERGE_RESULT=$?
+
+          # Always show merge output so Auto-merging lines appear in logs
+          echo "$MERGE_OUTPUT"
 
           if [ $MERGE_RESULT -eq 0 ]; then
             echo "[Sync] ✅ Merge successful with preserved history"
@@ -178,12 +181,26 @@ jobs:
             # where Next.js build artifacts have hashed filenames that change between builds.
             echo "[Sync] ⚠️ Merge had tree-level conflicts, resolving by accepting upstream..."
 
-            # Detect ALL unmerged paths using git ls-files --unmerged.
-            # Unlike 'git diff --diff-filter=U', this captures every conflict type:
-            #   - content conflicts (both sides modified same lines)
-            #   - modify/delete  (modified on one side, deleted on the other)
-            #   - rename/rename  (renamed differently on both sides)
-            #   - rename/delete  (renamed on one side, deleted on the other)
+            # --- Conflict Classification ---
+            # Parse conflict types from merge output for observability.
+            echo "::group::Conflict Classification"
+
+            RENAME_RENAME=$(echo "$MERGE_OUTPUT" | grep -c "CONFLICT (rename/rename)" || true)
+            MODIFY_DELETE=$(echo "$MERGE_OUTPUT" | grep -c "CONFLICT (modify/delete)" || true)
+            RENAME_DELETE=$(echo "$MERGE_OUTPUT" | grep -c "CONFLICT (rename/delete)" || true)
+            CONTENT_CONFLICTS=$(echo "$MERGE_OUTPUT" | grep -c "CONFLICT (content)" || true)
+
+            echo "[Sync] Conflict types:"
+            [ "$RENAME_RENAME" -gt 0 ] && echo "  rename/rename:  ${RENAME_RENAME}"
+            [ "$MODIFY_DELETE" -gt 0 ] && echo "  modify/delete:  ${MODIFY_DELETE}"
+            [ "$RENAME_DELETE" -gt 0 ] && echo "  rename/delete:  ${RENAME_DELETE}"
+            [ "$CONTENT_CONFLICTS" -gt 0 ] && echo "  content:        ${CONTENT_CONFLICTS}"
+
+            echo "::endgroup::"
+
+            # --- Detect Unmerged Paths ---
+            # git ls-files --unmerged captures every conflict type (unlike --diff-filter=U):
+            #   content, modify/delete, rename/rename, rename/delete
             UNMERGED_FILES=$(git ls-files --unmerged | awk '{print $4}' | sort -u)
 
             if [ -z "$UNMERGED_FILES" ]; then
@@ -192,13 +209,23 @@ jobs:
             fi
 
             CONFLICT_COUNT=$(echo "$UNMERGED_FILES" | wc -l | tr -d ' ')
-            echo "[Sync] Found ${CONFLICT_COUNT} conflicted paths:"
-            echo "$UNMERGED_FILES" | head -20
-            [ "$CONFLICT_COUNT" -gt 20 ] && echo "  ... and $((CONFLICT_COUNT - 20)) more"
 
-            # Resolve each conflict by accepting upstream (MERGE_HEAD) version.
-            # For each path: if it exists in the upstream tag, use their version;
-            # if it was deleted in the upstream tag, remove it from our tree.
+            # Group unmerged files by top-level directory
+            echo "::group::Affected Directories (${CONFLICT_COUNT} files)"
+            echo "$UNMERGED_FILES" | awk -F/ '{
+              if (NF >= 3) print $1"/"$2"/"$3"/";
+              else if (NF == 2) print $1"/"$2"/";
+              else print $1"/";
+            }' | sort | uniq -c | sort -rn | while read -r count dir; do
+              echo "  ${dir} ${count} files"
+            done
+            echo "::endgroup::"
+
+            # --- Resolve Conflicts ---
+            echo "::group::Resolving ${CONFLICT_COUNT} conflicts"
+
+            # For each unmerged path: if it exists in the upstream tag (MERGE_HEAD),
+            # accept their version; if deleted in upstream, remove from our tree.
             echo "$UNMERGED_FILES" | while read -r file; do
               if git cat-file -e "MERGE_HEAD:${file}" 2>/dev/null; then
                 echo "  - Accepting upstream: ${file}"
@@ -209,9 +236,21 @@ jobs:
               fi
             done
 
-            # Stage any remaining unstaged changes (e.g., orphaned files from
+            # Stage remaining unstaged changes (e.g., orphaned files from
             # rename/rename conflicts where HEAD's rename destination must be cleaned up)
             git add -A
+
+            echo "::endgroup::"
+
+            # --- Post-Resolution Validation ---
+            REMAINING=$(git ls-files --unmerged | wc -l | tr -d ' ')
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "[Sync] ❌ ${REMAINING} unmerged entries remain after resolution:"
+              git ls-files --unmerged | head -20
+              echo "[Sync] Manual intervention required"
+              exit 1
+            fi
+            echo "[Sync] ✅ Validation passed: no unmerged files remain"
 
             # Complete the merge commit
             git commit --no-edit -m "sync: merge ${NEW_VERSION} tag
@@ -219,7 +258,7 @@ jobs:
           Automatic sync from upstream BerriAI/litellm tag ${NEW_VERSION}
 
           Strategy: Merge with tree-level conflict resolution (accepted all upstream changes)
-          Conflicts resolved: ${CONFLICT_COUNT} files"
+          Conflicts resolved: ${CONFLICT_COUNT} files (${RENAME_RENAME} rename/rename, ${MODIFY_DELETE} modify/delete, ${RENAME_DELETE} rename/delete, ${CONTENT_CONFLICTS} content)"
 
             echo "[Sync] ✅ Tree-level conflicts resolved, merge completed with preserved history"
           fi


### PR DESCRIPTION
## Summary

Fixes the upstream sync workflow (`carto-upstream-sync-main.yml`) which has failed on the last 2 runs due to unhandled tree-level merge conflicts in Next.js build artifacts.

## What Changed

**Modified:**
- `.github/workflows/carto-upstream-sync-main.yml` — Merge + conflict resolution logic in the `sync-main-branch` job

## Root Cause

Two compounding bugs:

1. **`set -eu` kills the fallback** — The `git merge` command was a standalone statement, so when it returned non-zero, `set -e` terminated the script immediately. The conflict resolution fallback on the `else` branch was dead code that never executed.

2. **Fallback only detected content conflicts** — Even if it ran, `git diff --name-only --diff-filter=U` only captures content-level (both-modified) conflicts. The actual conflicts were tree-level types that `-X theirs` cannot resolve:
   - `rename/rename` (3) — Next.js build hash directories renamed differently on both sides
   - `rename/delete` (8) — JS chunks renamed in HEAD but deleted in upstream
   - `modify/delete` (11) — Files modified on one side, deleted on the other

All 22 conflicts were in `litellm/proxy/_experimental/out/` (generated Next.js static build output).

## Fix

### Commit 1: Core bug fix
1. **Capture merge exit code safely** — Use `git merge ... || MERGE_RESULT=$?` pattern. The `||` makes this a compound command, so `set -e` doesn't trigger on the left side's failure.

2. **Detect all conflict types** — Replace `git diff --diff-filter=U` with `git ls-files --unmerged | awk '{print $4}' | sort -u`, which captures every unmerged entry regardless of conflict type.

3. **Resolve per-file** — For each unmerged path, check if it exists at `MERGE_HEAD` (the upstream tag):
   - Exists → `git checkout MERGE_HEAD -- "$file"` (accept upstream version)
   - Deleted → `git rm -f "$file"` (remove from tree)
   - Then `git add -A` to clean up orphaned rename artifacts

### Commit 2: Observability & safety improvements
4. **Conflict classification** — Capture merge output and parse `CONFLICT (type)` lines to produce a typed summary (rename/rename, modify/delete, rename/delete, content) with collapsible `::group::` blocks.

5. **Directory grouping** — Group unmerged files by top-level directory (3 path components) for at-a-glance understanding.

6. **Post-resolution validation** — After resolving all conflicts, verify `git ls-files --unmerged` returns 0 entries before committing. Fails the job if anything was missed.

7. **Commit message traceability** — Include conflict type counts in the merge commit message.

## Failed Runs (evidence)

| Run | Date | Target | Error |
|-----|------|--------|-------|
| [#22852970280](https://github.com/CartoDB/litellm/actions/runs/22852970280) | 2026-03-09 | `v1.81.14-stable` | Tree-level conflicts in `_experimental/out/` |
| [#23143385304](https://github.com/CartoDB/litellm/actions/runs/23143385304) | 2026-03-16 | `v1.82.0-stable` | Same pattern, same directory |

## Local Dry-Run Test Results

Ran the exact script against the real `v1.82.0-stable` tag on an isolated local branch (never pushed). Results:

### Script Execution: PASSED
The merge failed as expected (same 22 CONFLICT lines as CI), then the fallback resolved all conflicts automatically.

### Conflict Classification: PASSED
```
Conflict types:
  rename/rename:  3
  modify/delete:  11
  rename/delete:  8

Affected Directories (20 files):
  litellm/proxy/_experimental/  20 files
```

### Resolution Actions
| Action | Count | Description |
|---|---|---|
| Accepting upstream | 6 | Files existing in upstream tag (3 hash dir files + 3 index.html) |
| Removing (deleted upstream) | 14 | Stale HEAD-only files (old build hashes + old rename targets) |

### Post-Resolution Validation: PASSED
`git ls-files --unmerged` returned **0** entries.

### File Integrity: PASSED
| Check | Result |
|---|---|
| Upstream files missing from our tree | **0** (all preserved) |
| Content differences vs upstream | **0** |
| `organizations/index.html` restored | Yes |
| `teams/index.html` restored | Yes |
| `tools/mcp-servers/index.html` restored | Yes |
| Old hash dir `FNzcPu...` removed | Yes |
| Old hash dir `C_XKHL...` (HEAD rename) removed | Yes |
| Upstream hash dir `U_YrOO...` present | Yes |
| `pyproject.toml` version | `1.82.0` |
| Working tree clean after commit | Yes |
| Merge commit has 2 parents | Yes |

### Productive Branches: UNTOUCHED
| Branch | Hash | Changed? |
|---|---|---|
| `carto/main` | `6452946` | No |
| `origin/main` | `eccba906` | No |

### Downstream Workflow Impact: NONE
Deep-dive analysis of all 6 upstream sync workflows confirmed no interference:
- **Resolver** (`carto-upstream-sync-resolver.yml`) — merges in opposite direction (carto/main into sync branch), unaffected
- **CI Fixer** — operates on sync branch only, unaffected
- **Ready Checker** — read-only PR status checks, unaffected
- **Conflict Detector** — triggered by pushes to carto/main, unaffected
- **Customizations Analyzer** — reads files from sync branch + carto/main, unaffected
- No workflow depends on `.gitattributes` or the specific conflict resolution method used in `sync-main-branch`

## Architectural Context

EAD: N/A - small change

## Review Focus Areas

**Critical areas:**
1. `.github/workflows/carto-upstream-sync-main.yml:162-264` — The new merge + fallback logic. Verify the `|| MERGE_RESULT=$?` pattern is safe with `set -eu`, and that `git ls-files --unmerged` + `git cat-file -e MERGE_HEAD:path` correctly handles all conflict types.

**Safe to skip:** No other files changed.

## Deployment Impact
- [x] Not applicable (CI workflow only)

## Migration & Breaking Changes
- [x] No migrations or breaking changes

## Security Considerations
- [x] No security impact

## Performance Impact
- [x] No performance impact

## Tests
- [x] No automated tests needed (CI workflow change)
- [x] Local dry-run test passed against real v1.82.0-stable tag (see results above)

## Dependencies
- None

## How to Validate

1. Merge this PR to `carto/main`
2. Manually trigger the upstream sync workflow (`workflow_dispatch`)
3. Verify the `sync-main-branch` job succeeds and resolves tree-level conflicts automatically
4. Check the merge commit message includes "Conflicts resolved: N files (X rename/rename, Y modify/delete, ...)"

## AI-Generated Code Notice
- [x] This PR contains AI-generated code
- [x] Areas requiring extra verification: Conflict resolution logic — ensure `git ls-files --unmerged` output parsing and `git cat-file -e MERGE_HEAD:path` behave as expected for all conflict types

## Checklist
- [x] PR title follows convention
- [x] One issue per PR
- [x] Local dry-run test passed
- [x] Downstream workflow impact analyzed (no interference)
- [x] AI review findings addressed