### PR TITLE
ci(gh-workflows): add image digest to n8n upstream-sync payload

### DIFF
--- a/.github/workflows/carto-n8n-notifier.yml
+++ b/.github/workflows/carto-n8n-notifier.yml
@@ -207,6 +207,35 @@ jobs:
           echo "[Notifier] JWT token generated successfully"
           echo "::endgroup::"
 
+      - name: Log in to GHCR
+        if: steps.pr-info.outputs.is-valid == 'true'
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.pr-info.outputs.is-valid == 'true'
+        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
+
+      - name: Resolve image digest
+        if: steps.pr-info.outputs.is-valid == 'true'
+        id: digest
+        run: |
+          set -eu
+          IMAGE="ghcr.io/${{ github.repository }}-non_root:${{ steps.pr-info.outputs.image-tag }}"
+          for i in 1 2 3 4 5; do
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+            if [[ "${DIGEST}" == sha256:* ]]; then
+              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Could not resolve digest for ${IMAGE}"
+          exit 1
+
       - name: Call n8n webhook
         if: steps.pr-info.outputs.is-valid == 'true'
         run: |
@@ -219,6 +248,7 @@ jobs:
             "event_type": "upstream_sync_ready",
             "version": "${{ steps.pr-info.outputs.version }}",
             "image_tag": "${{ steps.pr-info.outputs.image-tag }}",
+            "image_digest": "${{ steps.digest.outputs.digest }}",
             "pr_url": "${{ steps.pr-info.outputs.pr-url }}"
           }
           EOF
@@ -304,6 +334,32 @@ jobs:
           echo "[Notifier] JWT token generated successfully"
           echo "::endgroup::"
 
+      - name: Log in to GHCR
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
+
+      - name: Resolve image digest
+        id: digest
+        run: |
+          set -eu
+          IMAGE="ghcr.io/${{ github.repository }}-non_root:${{ github.event.release.tag_name }}"
+          for i in 1 2 3 4 5; do
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+            if [[ "${DIGEST}" == sha256:* ]]; then
+              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Could not resolve digest for ${IMAGE}"
+          exit 1
+
       - name: Call n8n webhook for release
         run: |
           set -eu
@@ -318,6 +374,7 @@ jobs:
             "event_type": "release",
             "version": "${RELEASE_TAG}",
             "image_tag": "${RELEASE_TAG}",
+            "image_digest": "${{ steps.digest.outputs.digest }}",
             "release_url": "${{ github.event.release.html_url }}"
           }
           EOF


### PR DESCRIPTION
## Summary

Make the n8n webhook payload carry the **sha256 digest** of the LiteLLM image so the cloud-native PR generator can pin by digest (`tag@sha256:…`) instead of by mutable tag.

Motivation: closes the same supply-chain attack class as the Trivy/GHCR incident — a compromised mutable tag silently flowing into cloud-native. With the digest in-payload, cloud-native PRs pin a verified manifest at notify time.

## Changes

- **`docker-build-multiarch.yaml`** — `merge` job resolves the merged multi-arch manifest digest (`imagetools inspect` on the first tag; all tags point at the same manifest) and exposes it as a reusable-workflow output (`image_digest`).
- **`carto-release.yaml`** — new `notify-n8n` job, chained after `docker`, owns the release-published webhook. The digest comes from the docker workflow output. The previous `release: published` listener in `carto-n8n-notifier.yml` fired in parallel with the push and couldn't see the digest — removed here.
- **`carto-n8n-notifier.yml`** — `notify-upstream-sync-ready` now resolves the sync-image digest at notify time (5 × 15s retries to absorb build/notify skew) and adds `image_digest` + `image_ref` to the payload. `release` trigger removed.
- **`.github/actions/n8n-jwt`** — composite action consolidating the 60-line ES256 JWT signing block (was duplicated 3×).

## New payload fields

```json
{
  "event_type": "upstream_sync_ready" | "release",
  "version": "v1.83.3-carto.1.19.6",
  "image_tag": "v1.83.3-carto.1.19.6",
  "image_digest": "sha256:abc…",
  "image_ref":   "ghcr.io/cartodb/litellm-non_root:<tag>@sha256:…",
  "pr_url" | "release_url": "…"
}
```

The cloud-native consumer (`litellm-upstream-sync.yml`) is updated in a follow-up PR.

## Test plan
- [ ] Trigger `workflow_dispatch` on `carto-n8n-notifier.yml` with `test_event=upstream_sync_ready` and a known tag+digest — confirm n8n receives the new fields.
- [ ] Run a no-op release once the cloud-native PR is ready; confirm `notify-n8n` job posts after `docker`.
- [ ] Verify only one release notification reaches n8n (no duplicate from the old release trigger).
