### PR TITLE
fix(oci): 🐛 restore inline-PEM key normalization dropped during upstream sync [sc-553919]

### DIFF
--- a/.github/carto-features.yml
+++ b/.github/carto-features.yml
@@ -19,6 +19,17 @@ features:
       - pattern: "_handle_tool_call_delta"
         file: litellm/responses/litellm_completion_transformation/streaming_iterator.py
 
+  - name: "OCI Inline PEM Key Normalization"
+    source_prs: [17159]
+    description: "Accepts the PEM private key as a string via oci_key, normalizes escaped newlines, and validates input type. Required for UI-based OCI credentials (textarea field)."
+    files:
+      - litellm/llms/oci/chat/transformation.py
+    verification:
+      - pattern: "oci_key must be a string containing the PEM private key content"
+        file: litellm/llms/oci/chat/transformation.py
+      - pattern: "load_private_key_from_str(oci_key_content)"
+        file: litellm/llms/oci/chat/transformation.py
+
   - name: "Snowflake Streaming + Tool Calling"
     source_prs: [38, 58]
     files:

--- a/litellm/llms/oci/chat/transformation.py
+++ b/litellm/llms/oci/chat/transformation.py
@@ -479,6 +479,19 @@ class OCIChatConfig(BaseConfig):
                 "Please install it with: pip install cryptography"
             ) from e
 
+        oci_key_content = None
+        if oci_key:
+            if isinstance(oci_key, str):
+                oci_key_content = oci_key.replace("\\n", "\n")
+                if "\r\n" in oci_key_content:
+                    oci_key_content = oci_key_content.replace("\r\n", "\n")
+            else:
+                raise OCIError(
+                    status_code=400,
+                    message=f"oci_key must be a string containing the PEM private key content. "
+                    f"Got type: {type(oci_key).__name__}",
+                )
+
         private_key = (
             load_private_key_from_str(oci_key_content)
             if oci_key_content
@@ -486,8 +499,9 @@ class OCIChatConfig(BaseConfig):
         )
 
         if private_key is None:
-            raise Exception(
-                "Private key is required for OCI authentication. Please provide either oci_key or oci_key_file."
+            raise OCIError(
+                status_code=400,
+                message="Private key is required for OCI authentication. Please provide either oci_key or oci_key_file.",
             )
 
         signature = private_key.sign(


### PR DESCRIPTION
## Summary

The May 19 upstream-sync merge (PR #106, commit `03c53bc4b3`) dropped the CARTO inline-PEM normalization block in `litellm/llms/oci/chat/transformation.py` but kept the upstream rename `oci_key` → `oci_key_content` in the `private_key` assignment. Net result: every OCI chat completion on this branch fails with `NameError: name 'oci_key_content' is not defined` at `_sign_with_manual_credentials`. Production (`v1.83.3-carto.1.19.6`) is unaffected because it predates the bad merge; `ded-29` running this build is.

## Root cause of the CI gap

`.github/carto-features.yml` is the manifest consumed by `carto-features-check.yml` to assert that critical CARTO patches survive each sync. The OCI Gemini tool-call feature (PR #68) was listed and the resolver restored it; the OCI inline-PEM feature (PR #17159, `2905feb889`) was not in the manifest, so the verifier had nothing to flag.

## Changes

- `litellm/llms/oci/chat/transformation.py` — re-apply the dropped block: define `oci_key_content`, normalize escaped `\n` / `\r\n` sequences, reject non-string `oci_key` with `OCIError`, and switch the missing-key path from bare `Exception` to `OCIError` (both behaviors from #17159).
- `.github/carto-features.yml` — add `OCI Inline PEM Key Normalization` (source PR 17159) with two verification patterns so future syncs fail loud if this regresses.

## Validation

`tests/litellm/llms/oci/chat/test_oci_chat_transformation.py::TestOCIKeyNormalization` — all 4 pass:

```
test_oci_key_with_escaped_newlines      PASSED
test_oci_key_with_crlf_newlines         PASSED
test_oci_key_rejects_non_string_type    PASSED
test_oci_key_rejects_list_type          PASSED
```

Manifest verifier locally — all 12 patterns OK (including the 2 new).

## Story

[sc-553919](https://app.shortcut.com/cartoteam/story/553919)