### PR TITLE
fix: stop Databricks streaming from rewriting tool_call arguments '{}' to ''

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -687,10 +687,6 @@ class DatabricksChatResponseIterator(BaseModelResponseIterator):
                                 message.content = ""
                             choice["delta"]["content"] = message.content
                             choice["delta"]["tool_calls"] = None
-                elif tool_calls:
-                    for _tc in tool_calls:
-                        if _tc.get("function", {}).get("arguments") == "{}":
-                            _tc["function"]["arguments"] = ""  # avoid invalid json
                 if isinstance(choice["delta"].get("content"), list) and (
                     content := choice["delta"]["content"]
                 ):

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -218,6 +218,43 @@ def test_chunk_parser_with_citation():
     }
 
 
+def test_chunk_parser_preserves_empty_object_tool_arguments():
+    # Regression: a previous "avoid invalid json" guard rewrote tool_call
+    # arguments from "{}" to "" when a single streaming chunk carried the
+    # complete empty-object payload. That made the persisted assistant
+    # message invalid on the next turn — downstream providers (Databricks
+    # included) reject `arguments: ""` with a JSON parse error.
+    iterator = DatabricksChatResponseIterator(None, sync_stream=True)
+    chunk = {
+        "id": "1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "test",
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_map_coordinates",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                "index": 0,
+                "finish_reason": None,
+            }
+        ],
+    }
+
+    parsed = iterator.chunk_parser(chunk)
+    assert parsed.choices[0].delta.tool_calls[0].function.arguments == "{}"
+
+
 def test_sanitize_empty_content_pops_none():
     message = {"role": "user", "content": None}
     _sanitize_empty_content(message)


### PR DESCRIPTION
## Summary

`DatabricksChatResponseIterator.chunk_parser` had a guard that rewrote tool_call `arguments` from the literal string `"{}"` to `""` (empty string), with a misleading `# avoid invalid json` comment. The polarity is backwards — `"{}"` is valid JSON, `""` is not.

When a downstream consumer persists the streamed assistant message and replays it on the next turn (e.g. the OpenAI Agents SDK in CARTO's `ai-api` v2 path), the invalid empty string gets sent back to Databricks, which rejects it:

```
400 DatabricksException - INVALID_PARAMETER_VALUE: Param 'arguments' in the
tool_calls function specification is not a valid JSON string.
No content to map due to end-of-input
```

This affects any parameterless tool call (`get_map_coordinates`, `get_spatial_filter`, `get_active_filters`, etc.) where Databricks streams the complete `{}` argument payload in a single chunk.

Fixes [sc-554339](https://app.shortcut.com/cartoteam/story/554339).

## Changes

- `litellm/llms/databricks/chat/transformation.py` — delete the `elif tool_calls:` rewrite block at lines 690-693.
- `tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py` — add `test_chunk_parser_preserves_empty_object_tool_arguments` regression test.

## Test plan

- [x] New regression test passes with the fix; verified it fails without the fix (`assert '' == '{}'`).
- [x] Full `test_databricks_chat_transformation.py` suite: 12/12 pass.
- [ ] Validate end-to-end against a CARTO devkit map agent using a non-GPT Databricks model (`databricks-claude-opus-4-7`) once a new LiteLLM image carrying this fix is built.

## Notes

The deleted block was clearly intended to handle some real downstream surface that didn't like `{}` — but no test, comment, or commit message documents which one. Removing it is the smaller change than auditing every consumer; if a regression surfaces we can re-introduce a targeted normalization closer to the consumer that actually needed it.