### PR TITLE
fix: strip OpenAI 'annotations' field from outbound Databricks chat messages

### DIFF
--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -93,6 +93,37 @@ def _sanitize_empty_content(message_dict: dict[str, Any]) -> None:
             message_dict["content"] = filtered
 
 
+def _normalize_empty_tool_call_arguments(message_dict: dict[str, Any]) -> None:
+    """
+    Restore `tool_calls[].function.arguments` to a valid JSON empty object
+    when it is missing or an empty string.
+
+    Databricks's streaming protocol emits parameterless tool_call arguments
+    as one or two empty-string deltas (no `{}`), which accumulate to `""` in
+    the consumer. When that assistant message is replayed on a follow-up
+    turn (e.g. via the OpenAI Agents SDK conversation history), Databricks
+    Model Serving rejects it with:
+
+        INVALID_PARAMETER_VALUE: Param 'arguments' in the tool_calls
+        function specification is not a valid JSON string. No content to
+        map due to end-of-input
+
+    Coercing empty/missing arguments to `"{}"` is safe because that is the
+    canonical JSON representation of a parameterless call.
+    """
+    tool_calls = message_dict.get("tool_calls")
+    if not isinstance(tool_calls, list):
+        return
+    for tc in tool_calls:
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function")
+        if not isinstance(fn, dict):
+            continue
+        if not fn.get("arguments"):
+            fn["arguments"] = "{}"
+
+
 def _strip_openai_annotations(message_dict: dict[str, Any]) -> None:
     """
     Remove the OpenAI-only `annotations` field from each content block.
@@ -399,6 +430,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
                 _message = self._move_cache_control_into_string_content_block(_message)
             _sanitize_empty_content(cast(dict[str, Any], _message))
             _strip_openai_annotations(cast(dict[str, Any], _message))
+            _normalize_empty_tool_call_arguments(cast(dict[str, Any], _message))
             new_messages.append(_message)
 
         if is_async:

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -737,6 +737,19 @@ class DatabricksChatResponseIterator(BaseModelResponseIterator):
                                 message.content = ""
                             choice["delta"]["content"] = message.content
                             choice["delta"]["tool_calls"] = None
+                elif tool_calls:
+                    # Databricks streams parameterless tool_call arguments as
+                    # a sequence of empty-string deltas, which accumulate to
+                    # `""` in the consumer (OpenAI Agents SDK, frontend tool
+                    # runners) — invalid JSON. On the name-introducing chunk
+                    # default arguments to `"{}"` so accumulation ends up
+                    # valid JSON. Subsequent empty-string deltas concatenate
+                    # harmlessly.
+                    for _tc in tool_calls:
+                        fn = _tc.get("function") or {}
+                        if fn.get("name") and not fn.get("arguments"):
+                            fn["arguments"] = "{}"
+                            _tc["function"] = fn
                 if isinstance(choice["delta"].get("content"), list) and (
                     content := choice["delta"]["content"]
                 ):

--- a/litellm/llms/databricks/chat/transformation.py
+++ b/litellm/llms/databricks/chat/transformation.py
@@ -93,6 +93,23 @@ def _sanitize_empty_content(message_dict: dict[str, Any]) -> None:
             message_dict["content"] = filtered
 
 
+def _strip_openai_annotations(message_dict: dict[str, Any]) -> None:
+    """
+    Remove the OpenAI-only `annotations` field from each content block.
+    Databricks Model Serving uses Anthropic Messages API spec and rejects
+    `annotations` with `Extra inputs are not permitted`. The field appears
+    on chat-completion assistant messages emitted by OpenAI-compatible
+    providers (for citation parity with the Responses API) and survives the
+    Agents SDK replay on every follow-up turn.
+    """
+    content = message_dict.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and "annotations" in block:
+            block.pop("annotations", None)
+
+
 if TYPE_CHECKING:
     from litellm.litellm_core_utils.litellm_logging import Logging as _LiteLLMLoggingObj
 
@@ -381,6 +398,7 @@ class DatabricksConfig(DatabricksBase, OpenAILikeChatConfig, AnthropicConfig):
             if "cache_control" in _message and isinstance(_message.get("content"), str):
                 _message = self._move_cache_control_into_string_content_block(_message)
             _sanitize_empty_content(cast(dict[str, Any], _message))
+            _strip_openai_annotations(cast(dict[str, Any], _message))
             new_messages.append(_message)
 
         if is_async:

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -14,6 +14,7 @@ from litellm.llms.databricks.chat.transformation import (
     DatabricksChatResponseIterator,
     DatabricksConfig,
     _sanitize_empty_content,
+    _strip_openai_annotations,
 )
 
 
@@ -297,3 +298,69 @@ def test_transform_messages_sanitizes_empty_content():
     )
     assert "content" not in result[0]
     assert result[1]["content"] == "Hi"
+
+
+def test_strip_openai_annotations_removes_annotations_field():
+    message = {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "text",
+                "text": "Hello",
+                "annotations": [
+                    {
+                        "type": "url_citation",
+                        "url_citation": {"url": "https://example.com"},
+                    }
+                ],
+            }
+        ],
+    }
+    _strip_openai_annotations(message)
+    assert message["content"] == [{"type": "text", "text": "Hello"}]
+
+
+def test_strip_openai_annotations_leaves_string_content_untouched():
+    message = {"role": "user", "content": "Hi"}
+    _strip_openai_annotations(message)
+    assert message["content"] == "Hi"
+
+
+def test_strip_openai_annotations_noop_when_no_annotations():
+    message = {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello"}],
+    }
+    _strip_openai_annotations(message)
+    assert message["content"] == [{"type": "text", "text": "Hello"}]
+
+
+def test_transform_messages_strips_annotations_from_assistant_content():
+    # Regression: Databricks Model Serving rejects assistant messages whose
+    # content blocks carry an `annotations` field (OpenAI chat-completion
+    # citation parity). The Agents SDK persists this verbatim and replays it
+    # on the next turn, causing a 400 BAD_REQUEST:
+    #   messages.<n>.content.<m>.text.annotations: Extra inputs are not permitted
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "Hi"},
+        {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Hello there",
+                    "annotations": [
+                        {
+                            "type": "url_citation",
+                            "url_citation": {"url": "https://example.com"},
+                        }
+                    ],
+                }
+            ],
+        },
+    ]
+    result = config._transform_messages(
+        messages=messages, model="databricks-claude", is_async=False
+    )
+    assert result[1]["content"] == [{"type": "text", "text": "Hello there"}]

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -220,6 +220,71 @@ def test_chunk_parser_with_citation():
     }
 
 
+def test_chunk_parser_defaults_empty_arguments_on_name_chunk():
+    # Regression: Databricks streams parameterless tool_call arguments as
+    # empty-string deltas. Without coercion the consumer accumulates `""` and
+    # downstream `JSON.parse` fails. The name-introducing chunk (the one
+    # carrying `function.name`) seeds the accumulation with `"{}"`; later
+    # empty-string deltas concatenate harmlessly.
+    iterator = DatabricksChatResponseIterator(None, sync_stream=True)
+    name_chunk = {
+        "id": "1",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "test",
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_map_coordinates",
+                                "arguments": "",
+                            },
+                        }
+                    ],
+                },
+                "index": 0,
+                "finish_reason": None,
+            }
+        ],
+    }
+    parsed = iterator.chunk_parser(name_chunk)
+    assert parsed.choices[0].delta.tool_calls[0].function.arguments == "{}"
+
+
+def test_chunk_parser_leaves_subsequent_empty_args_chunks_untouched():
+    # The name-only chunk seeds "{}". Subsequent args-only chunks with
+    # empty-string deltas must stay empty to avoid double-accumulation
+    # (otherwise the consumer would end with "{}{}" — invalid JSON).
+    iterator = DatabricksChatResponseIterator(None, sync_stream=True)
+    args_chunk = {
+        "id": "2",
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "test",
+        "choices": [
+            {
+                "delta": {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "function": {"arguments": ""},
+                        }
+                    ],
+                },
+                "index": 0,
+                "finish_reason": None,
+            }
+        ],
+    }
+    parsed = iterator.chunk_parser(args_chunk)
+    assert parsed.choices[0].delta.tool_calls[0].function.arguments == ""
+
+
 def test_chunk_parser_preserves_empty_object_tool_arguments():
     # Regression: a previous "avoid invalid json" guard rewrote tool_call
     # arguments from "{}" to "" when a single streaming chunk carried the

--- a/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
+++ b/tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 from litellm.llms.databricks.chat.transformation import (
     DatabricksChatResponseIterator,
     DatabricksConfig,
+    _normalize_empty_tool_call_arguments,
     _sanitize_empty_content,
     _strip_openai_annotations,
 )
@@ -364,3 +365,89 @@ def test_transform_messages_strips_annotations_from_assistant_content():
         messages=messages, model="databricks-claude", is_async=False
     )
     assert result[1]["content"] == [{"type": "text", "text": "Hello there"}]
+
+
+def test_normalize_empty_tool_call_arguments_replaces_empty_string():
+    message = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_map_coordinates", "arguments": ""},
+            }
+        ],
+    }
+    _normalize_empty_tool_call_arguments(message)
+    assert message["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+def test_normalize_empty_tool_call_arguments_replaces_missing_field():
+    message = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "get_map_coordinates"},
+            }
+        ],
+    }
+    _normalize_empty_tool_call_arguments(message)
+    assert message["tool_calls"][0]["function"]["arguments"] == "{}"
+
+
+def test_normalize_empty_tool_call_arguments_preserves_valid_args():
+    message = {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "tool", "arguments": '{"a": 1}'},
+            }
+        ],
+    }
+    _normalize_empty_tool_call_arguments(message)
+    assert message["tool_calls"][0]["function"]["arguments"] == '{"a": 1}'
+
+
+def test_normalize_empty_tool_call_arguments_noop_without_tool_calls():
+    message = {"role": "user", "content": "Hi"}
+    _normalize_empty_tool_call_arguments(message)
+    assert message == {"role": "user", "content": "Hi"}
+
+
+def test_transform_messages_normalizes_empty_tool_call_arguments():
+    # Regression: Databricks streams parameterless tool_call arguments as ""
+    # (instead of "{}"). The OpenAI Agents SDK accumulates and persists the
+    # empty string, then replays it on the next turn. Databricks rejects with:
+    #   INVALID_PARAMETER_VALUE: Param 'arguments' in the tool_calls function
+    #   specification is not a valid JSON string. No content to map due to
+    #   end-of-input
+    config = DatabricksConfig()
+    messages = [
+        {"role": "user", "content": "Use the tool"},
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "get_map_coordinates",
+                        "arguments": "",
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "content": '{"lat": 0, "lon": 0}',
+        },
+    ]
+    result = config._transform_messages(
+        messages=messages, model="databricks-claude", is_async=False
+    )
+    assert result[1]["tool_calls"][0]["function"]["arguments"] == "{}"


### PR DESCRIPTION
## Summary

Companion to [#109](https://github.com/CartoDB/litellm/pull/109). #109 fixed the streaming-side corruption that broke turn-1 tool calls; this one fixes the request-side corruption that breaks turn 2+ of any conversation.

OpenAI added an `annotations` field to chat-completion content blocks for citation parity with the Responses API. LiteLLM normalizes every provider response to that spec, so even when the upstream is Anthropic-via-Databricks (e.g. `databricks-claude-sonnet-4-6`) the chat-completion response surfaced to the caller may include `annotations` on text content blocks.

The OpenAI Agents SDK persists this OpenAI-shaped history verbatim and replays it on every follow-up turn. Databricks Model Serving rejects the unknown field on input with:

```
400 BAD_REQUEST - messages.<n>.content.<m>.text.annotations:
Extra inputs are not permitted
```

Symptom in CARTO: turn 1 of a UI chat against `databricks-claude-*` succeeds; turn 2 always fails with the above.

## Changes

- `litellm/llms/databricks/chat/transformation.py` — new `_strip_openai_annotations()` helper next to `_sanitize_empty_content`, called from `_transform_messages` so every outbound message has `annotations` stripped from its content blocks.
- `tests/test_litellm/llms/databricks/chat/test_databricks_chat_transformation.py` — four regression tests:
  - Helper unit: strips `annotations`, ignores string content, no-op when absent.
  - Transformer integration: assistant message with `annotations` survives `_transform_messages` cleanly.

## Test plan

- [x] New tests pass with the fix; bisect-verified the transformer test fails without the call site.
- [x] Full `test_databricks_chat_transformation.py` suite: 16/16 pass.
- [ ] Validate end-to-end against a CARTO devkit / ded29 with a non-GPT Databricks model — exercise a multi-turn chat (turn 2 was the failure mode).

## Notes

- Function name (`_strip_openai_annotations`) refers to the schema origin (OpenAI chat-completion spec), not the underlying model. The field leaks regardless of which model is behind LiteLLM.
- PR is rooted at the post-#109 tip of `upstream-sync/v1.83.14-stable`, so the build image will carry v1.83.14 + #109's chunk-parser fix + this fix.