### PR TITLE
fix(snowflake): unblock Claude function-calling follow-up turns on Cortex

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -31,6 +31,47 @@ else:
     LiteLLMLoggingObj = Any
 
 
+def _strip_openai_annotations(message_dict: Dict[str, Any]) -> None:
+    """
+    Remove the OpenAI-only `annotations` field from each content block.
+    Snowflake Cortex rejects unknown fields inside text content blocks with
+    `390142 Incoming request does not contain a valid payload`. The field
+    appears on assistant messages emitted by OpenAI-compatible providers
+    (for citation parity with the Responses API) and survives the Agents
+    SDK replay on every follow-up turn.
+    """
+    content = message_dict.get("content")
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if isinstance(block, dict) and "annotations" in block:
+            block.pop("annotations", None)
+
+
+def _content_to_text_blocks(content: Any) -> List[Dict[str, Any]]:
+    """
+    Convert an OpenAI-style assistant `content` value into a list of Snowflake
+    `{"type": "text", "text": ...}` blocks suitable for inclusion in
+    `content_list`. Empty/whitespace-only text is dropped.
+    """
+    if not content:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content.strip() else []
+    if isinstance(content, list):
+        blocks: List[Dict[str, Any]] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") != "text":
+                continue
+            text = block.get("text") or ""
+            if isinstance(text, str) and text.strip():
+                blocks.append({"type": "text", "text": text})
+        return blocks
+    return []
+
+
 class SnowflakeStreamingHandler(BaseModelResponseIterator):
     """
     Custom streaming handler for Snowflake that handles missing fields in chunk responses.
@@ -49,18 +90,39 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
 
             # Check if this is a tool_use block (Claude format via Snowflake)
             if delta.get("type") == "tool_use":
+                name = delta.get("name")
+
+                # Normalize `input` into a JSON string for the OpenAI delta shape.
+                # Cortex routes Claude through Bedrock, which emits parameterless
+                # tool_use chunks with `input=""` instead of `input={}`. The SDK
+                # would accumulate the empty string into an invalid arguments
+                # value (JSON.parse fails on ""), which then poisons the
+                # conversation history on the next turn. Seed `"{}"` on the
+                # name-introducing chunk so accumulation ends up valid JSON.
+                input_value = delta.get("input")
+                if isinstance(input_value, dict):
+                    arguments = json.dumps(input_value)
+                elif isinstance(input_value, str):
+                    arguments = input_value
+                else:
+                    arguments = ""
+                if name and not arguments:
+                    arguments = "{}"
+
                 tool_call = ChatCompletionDeltaToolCall(
                     id=delta.get("tool_use_id") or delta.get("id"),
                     type="function",
                     function=Function(
-                        name=delta.get("name"),
-                        arguments=delta.get("input", ""),
+                        name=name,
+                        arguments=arguments,
                     ),
                     index=choice.get("index", 0),
                 )
                 delta["tool_calls"] = [tool_call]
                 delta.pop("type", None)
                 delta.pop("tool_use_id", None)
+                delta.pop("input", None)
+                delta.pop("name", None)
                 delta.pop("content_list", None)
 
         return ModelResponseStream(
@@ -324,9 +386,15 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
         Handles:
         - role="tool" messages -> role="user" with content_list containing tool_results
         - role="assistant" with tool_calls -> content_list with tool_use blocks
+        - consecutive assistant messages (text-only followed by tool_call-only,
+          as the OpenAI Agents SDK replays them) -> merged into a single
+          assistant message with both text and tool_use blocks. Snowflake
+          Cortex rejects role-alternation violations with 390142.
+        - OpenAI `annotations: []` on content blocks -> stripped. Snowflake
+          Cortex rejects unknown fields with 390142.
         - content=None -> content="" (Snowflake requires non-null content)
         """
-        transformed_messages = []
+        transformed_messages: List[Dict[str, Any]] = []
         tool_call_map: Dict[str, str] = {}
 
         for message in messages:
@@ -358,7 +426,7 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
             # Handle assistant messages with tool_calls
             elif msg_dict.get("role") == "assistant" and msg_dict.get("tool_calls"):
-                content_list = []
+                tool_use_blocks: List[Dict[str, Any]] = []
 
                 for tool_call in msg_dict.get("tool_calls", []):
                     if tool_call.get("type") == "function":
@@ -370,16 +438,23 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                         if tc_id and tc_name:
                             tool_call_map[tc_id] = tc_name
 
-                        try:
-                            arguments = (
-                                json.loads(arguments_str)
-                                if isinstance(arguments_str, str)
-                                else arguments_str
-                            )
-                        except json.JSONDecodeError:
-                            arguments = {}
+                        # Empty/missing arguments → parameterless call. The
+                        # Cortex-via-Bedrock streaming path leaves
+                        # `arguments=""` on the SDK side; coerce to a valid
+                        # empty object before serialization.
+                        if not arguments_str:
+                            arguments: Any = {}
+                        else:
+                            try:
+                                arguments = (
+                                    json.loads(arguments_str)
+                                    if isinstance(arguments_str, str)
+                                    else arguments_str
+                                )
+                            except json.JSONDecodeError:
+                                arguments = {}
 
-                        content_list.append({
+                        tool_use_blocks.append({
                             "type": "tool_use",
                             "tool_use": {
                                 "tool_use_id": tc_id,
@@ -387,6 +462,26 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                                 "input": arguments,
                             },
                         })
+
+                # Merge with the immediately preceding assistant message if it
+                # carried only text and no content_list / tool_calls. The
+                # OpenAI Agents SDK replays a tool-using turn as two separate
+                # assistant messages (text first, tool_call second); Snowflake
+                # Cortex expects a single assistant message per turn whose
+                # content_list contains both text and tool_use blocks.
+                text_prelude_blocks: List[Dict[str, Any]] = []
+                if (
+                    transformed_messages
+                    and transformed_messages[-1].get("role") == "assistant"
+                    and not transformed_messages[-1].get("content_list")
+                    and not transformed_messages[-1].get("tool_calls")
+                ):
+                    prev = transformed_messages.pop()
+                    text_prelude_blocks = _content_to_text_blocks(
+                        prev.get("content")
+                    )
+
+                content_list = text_prelude_blocks + tool_use_blocks
 
                 transformed_messages.append({
                     "role": "assistant",
@@ -399,6 +494,8 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
                     msg_to_append = message.copy()
                 else:
                     msg_to_append = dict(message)
+
+                _strip_openai_annotations(msg_to_append)
 
                 content_value = msg_to_append.get("content")
                 has_content_list = "content_list" in msg_to_append and msg_to_append.get("content_list")

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -885,3 +885,547 @@ class TestSnowflakeStreamingHandler:
         )
 
         assert isinstance(handler, SnowflakeStreamingHandler)
+
+
+class TestSnowflakeCortex390142Fixes:
+    """
+    Regression coverage for sc-554963 — Snowflake Cortex `390142 Incoming
+    request does not contain a valid payload` on Claude function-calling
+    follow-up turns.
+
+    Three root causes (mirrors the Databricks PR #110 family + one
+    Snowflake-specific schema fix):
+
+    1. Streaming tool_use chunks emit `input=""` for parameterless calls
+       (Bedrock-Anthropic quirk) → SDK accumulates `""` → invalid JSON →
+       poisoned conversation history. Fix: seed `"{}"` on the
+       name-introducing chunk.
+    2. OpenAI-compatible providers emit `annotations: []` inside text
+       content blocks; Snowflake rejects unknown fields. Fix: strip.
+    3. The Agents SDK replays a tool-using turn as TWO consecutive
+       assistant messages (text-only, then tool_call-only). Snowflake
+       expects one assistant message per turn. Fix: merge.
+    """
+
+    # ----- chunk_parser: empty-args seeding ----------------------------
+
+    def _make_handler(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            SnowflakeStreamingHandler,
+        )
+
+        return SnowflakeStreamingHandler.__new__(SnowflakeStreamingHandler)
+
+    def _tool_use_chunk(self, **delta_overrides):
+        delta = {"type": "tool_use", "tool_use_id": "tu1"}
+        delta.update(delta_overrides)
+        return {
+            "id": "chunk-1",
+            "model": "claude-3-5-sonnet",
+            "created": 1,
+            "choices": [{"index": 0, "delta": delta}],
+        }
+
+    def test_chunk_parser_seeds_empty_string_input_with_braces(self):
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(
+            self._tool_use_chunk(name="get_coords", input="")
+        )
+
+        tc = result.choices[0].delta.tool_calls[0]
+        assert tc.function.arguments == "{}"
+        assert tc.function.name == "get_coords"
+
+    def test_chunk_parser_seeds_missing_input_with_braces(self):
+        handler = self._make_handler()
+
+        chunk = self._tool_use_chunk(name="get_coords")
+        # No `input` key at all.
+        result = handler.chunk_parser(chunk)
+
+        tc = result.choices[0].delta.tool_calls[0]
+        assert tc.function.arguments == "{}"
+
+    def test_chunk_parser_serializes_dict_input_to_json_string(self):
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(
+            self._tool_use_chunk(
+                name="wx", input={"location": "Madrid", "unit": "celsius"}
+            )
+        )
+
+        tc = result.choices[0].delta.tool_calls[0]
+        # ChatCompletionDeltaToolCall.arguments must be a string for the
+        # downstream SDK to accumulate correctly.
+        assert isinstance(tc.function.arguments, str)
+        parsed = json.loads(tc.function.arguments)
+        assert parsed == {"location": "Madrid", "unit": "celsius"}
+
+    def test_chunk_parser_passes_through_partial_json_string(self):
+        """
+        Subsequent delta chunks (no name, partial JSON in `input`) must
+        pass through untouched so consumers can accumulate them.
+        """
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(
+            self._tool_use_chunk(name=None, input='{"loc')
+        )
+
+        tc = result.choices[0].delta.tool_calls[0]
+        assert tc.function.arguments == '{"loc'
+
+    def test_chunk_parser_does_not_seed_when_no_name(self):
+        """
+        Empty `input` on a continuation chunk (no name) must not be
+        rewritten — only the name-introducing chunk seeds.
+        """
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(
+            self._tool_use_chunk(name=None, input="")
+        )
+
+        tc = result.choices[0].delta.tool_calls[0]
+        assert tc.function.arguments == ""
+
+    def test_chunk_parser_strips_snowflake_specific_delta_fields(self):
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(
+            self._tool_use_chunk(name="get_coords", input="")
+        )
+
+        delta = result.choices[0].delta
+        # `type`, `tool_use_id`, `input`, `name`, and `content_list`
+        # should be removed in favour of the OpenAI-shaped `tool_calls`.
+        for snowflake_field in ("type", "tool_use_id", "input", "name", "content_list"):
+            assert not hasattr(delta, snowflake_field) or getattr(delta, snowflake_field) is None
+
+    # ----- _strip_openai_annotations ----------------------------------
+
+    def test_strip_openai_annotations_removes_field(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _strip_openai_annotations,
+        )
+
+        message = {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "hi", "annotations": []},
+                {"type": "text", "text": "there", "annotations": [{"x": 1}]},
+            ],
+        }
+
+        _strip_openai_annotations(message)
+
+        assert "annotations" not in message["content"][0]
+        assert "annotations" not in message["content"][1]
+        # Other fields preserved.
+        assert message["content"][0] == {"type": "text", "text": "hi"}
+
+    def test_strip_openai_annotations_is_noop_on_string_content(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _strip_openai_annotations,
+        )
+
+        message = {"role": "user", "content": "hello"}
+        _strip_openai_annotations(message)
+        assert message == {"role": "user", "content": "hello"}
+
+    def test_strip_openai_annotations_is_noop_on_none_content(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _strip_openai_annotations,
+        )
+
+        message = {"role": "assistant", "content": None}
+        _strip_openai_annotations(message)
+        assert message == {"role": "assistant", "content": None}
+
+    # ----- _content_to_text_blocks ------------------------------------
+
+    def test_content_to_text_blocks_from_string(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _content_to_text_blocks,
+        )
+
+        assert _content_to_text_blocks("hello") == [
+            {"type": "text", "text": "hello"}
+        ]
+
+    def test_content_to_text_blocks_drops_empty_and_non_text(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _content_to_text_blocks,
+        )
+
+        blocks = _content_to_text_blocks(
+            [
+                {"type": "text", "text": "a", "annotations": []},
+                {"type": "text", "text": "   "},  # whitespace-only → drop
+                {"type": "tool_use", "tool_use": {}},  # non-text → drop
+                {"type": "text", "text": "b"},
+            ]
+        )
+
+        assert blocks == [
+            {"type": "text", "text": "a"},
+            {"type": "text", "text": "b"},
+        ]
+
+    def test_content_to_text_blocks_handles_empty_inputs(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _content_to_text_blocks,
+        )
+
+        assert _content_to_text_blocks("") == []
+        assert _content_to_text_blocks(None) == []
+        assert _content_to_text_blocks([]) == []
+        assert _content_to_text_blocks("   ") == []
+
+    # ----- _transform_messages: consecutive-assistant merge -----------
+
+    def test_transform_messages_merges_consecutive_assistant_messages(self):
+        """
+        Reproduces the captured failing payload shape from sc-554963:
+        an assistant text message immediately followed by an assistant
+        tool_call message. After transform they should be a single
+        assistant message with content_list containing the text block
+        first and the tool_use block second.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Call get_map_coordinates."},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "I'll call the tool.",
+                            "annotations": [],
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_bdrk_01",
+                            "type": "function",
+                            "function": {
+                                "name": "get_map_coordinates",
+                                "arguments": "",
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
+
+        # user + ONE merged assistant
+        assert len(transformed) == 2
+        assert transformed[0]["role"] == "user"
+
+        assistant = transformed[1]
+        assert assistant["role"] == "assistant"
+        assert assistant["content"] == ""
+        assert len(assistant["content_list"]) == 2
+
+        text_block, tool_block = assistant["content_list"]
+        # Text prelude carried over (and annotations stripped).
+        assert text_block == {"type": "text", "text": "I'll call the tool."}
+        # Tool_use built from the second message with empty args coerced
+        # to {} (parameterless call).
+        assert tool_block["type"] == "tool_use"
+        assert tool_block["tool_use"]["tool_use_id"] == "toolu_bdrk_01"
+        assert tool_block["tool_use"]["name"] == "get_map_coordinates"
+        assert tool_block["tool_use"]["input"] == {}
+
+    def test_transform_messages_does_not_merge_when_previous_has_content_list(self):
+        """
+        A previous assistant that already carried tool_calls should not
+        be merged with the next assistant — they belong to different
+        turns separated by a tool_result.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "First."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu1",
+                            "type": "function",
+                            "function": {"name": "first", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": "tu1", "content": "ok"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu2",
+                            "type": "function",
+                            "function": {"name": "second", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ]
+        )
+
+        # user + assistant + user(tool_results) + assistant — no merge.
+        assert len(transformed) == 4
+        assert transformed[1]["role"] == "assistant"
+        assert transformed[2]["role"] == "user"
+        assert transformed[3]["role"] == "assistant"
+
+    def test_transform_messages_does_not_merge_across_non_assistant(self):
+        """
+        If a non-assistant message sits between two assistants, merging
+        must not happen.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "First."},
+                {"role": "assistant", "content": "I think..."},
+                {"role": "user", "content": "Now do something."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu1",
+                            "type": "function",
+                            "function": {"name": "do_it", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ]
+        )
+
+        assert len(transformed) == 4
+        # The first assistant remains a plain text message.
+        assert transformed[1]["role"] == "assistant"
+        assert transformed[1].get("content_list") in (None, [])
+        # The second assistant has just the tool_use block, no prelude.
+        last = transformed[3]
+        assert len(last["content_list"]) == 1
+        assert last["content_list"][0]["type"] == "tool_use"
+
+    def test_transform_messages_strips_annotations_on_plain_assistant(self):
+        """
+        Annotations must be stripped from plain (non-merged) assistant
+        text messages as well — Cortex rejects them with 390142
+        regardless of merge.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Hello there.",
+                            "annotations": [],
+                        }
+                    ],
+                },
+            ]
+        )
+
+        assert "annotations" not in transformed[1]["content"][0]
+
+    def test_transform_messages_empty_tool_call_arguments_coerced_to_empty_dict(self):
+        """
+        Without a merge in play, an assistant message with `tool_calls`
+        whose `arguments=""` must still serialize to `input={}` in the
+        Snowflake tool_use block — Snowflake's schema requires an object
+        for `input`, not an empty string.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Call it."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_coords",
+                                "arguments": "",
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
+
+        tool_use = transformed[1]["content_list"][0]
+        assert tool_use["tool_use"]["input"] == {}
+
+    def test_transform_messages_missing_tool_call_arguments_coerced_to_empty_dict(self):
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Call it."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu1",
+                            "type": "function",
+                            "function": {"name": "get_coords"},
+                            # no `arguments` key at all
+                        }
+                    ],
+                },
+            ]
+        )
+
+        tool_use = transformed[1]["content_list"][0]
+        assert tool_use["tool_use"]["input"] == {}
+
+    def test_transform_messages_preserves_non_empty_arguments(self):
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Get the weather."},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "tu1",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"location": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+            ]
+        )
+
+        tool_use = transformed[1]["content_list"][0]
+        assert tool_use["tool_use"]["input"] == {"location": "Paris"}
+
+    def test_transform_messages_end_to_end_captured_failing_payload(self):
+        """
+        Full end-to-end smoke test against the exact shape captured from
+        the sc-554963 production HAR (annotations + two-consecutive
+        assistants + empty-string arguments + synthetic tool_result).
+
+        After the fixes the Snowflake-bound payload must:
+        - have a SINGLE assistant message per turn (no consecutive
+          same-role messages),
+        - carry NO `annotations` fields anywhere in content blocks,
+        - have `tool_use.input` as `{}` (object), not `""`.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "system", "content": "You are an assistant."},
+                {
+                    "role": "user",
+                    "content": "Call get_map_coordinates and echo the result.",
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "I'll call the tool and share the result.",
+                            "annotations": [],
+                        }
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "toolu_bdrk_01U31Y2KLfXpuoeg2f2DqgcU",
+                            "type": "function",
+                            "function": {
+                                "name": "get_map_coordinates",
+                                "arguments": "",
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "toolu_bdrk_01U31Y2KLfXpuoeg2f2DqgcU",
+                    "name": "get_map_coordinates",
+                    "content": '{"latitude": 40.4168, "longitude": -3.7038}',
+                },
+            ]
+        )
+
+        # Expected shape: system, user, merged-assistant, user(tool_results)
+        assert [m["role"] for m in transformed] == [
+            "system",
+            "user",
+            "assistant",
+            "user",
+        ]
+
+        # No consecutive same-role messages.
+        for i in range(len(transformed) - 1):
+            assert transformed[i]["role"] != transformed[i + 1]["role"]
+
+        # The merged assistant: text prelude + tool_use, no annotations
+        # leaked anywhere, input is an object.
+        merged = transformed[2]
+        assert len(merged["content_list"]) == 2
+        text_block, tool_block = merged["content_list"]
+        assert text_block == {
+            "type": "text",
+            "text": "I'll call the tool and share the result.",
+        }
+        assert tool_block["tool_use"]["input"] == {}
+        assert tool_block["tool_use"]["name"] == "get_map_coordinates"
+
+        # tool_result wrapped into user message with content_list.
+        tool_user = transformed[3]
+        assert tool_user["content_list"][0]["type"] == "tool_results"
+        assert (
+            tool_user["content_list"][0]["tool_results"]["tool_use_id"]
+            == "toolu_bdrk_01U31Y2KLfXpuoeg2f2DqgcU"
+        )
+
+        # Recursively assert no `annotations` field survives anywhere in
+        # the transformed payload — this is the field Snowflake rejects.
+        def _no_annotations(obj):
+            if isinstance(obj, dict):
+                assert "annotations" not in obj, f"annotations leaked in {obj}"
+                for v in obj.values():
+                    _no_annotations(v)
+            elif isinstance(obj, list):
+                for item in obj:
+                    _no_annotations(item)
+
+        _no_annotations(transformed)


### PR DESCRIPTION
## Summary

Three independent issues caused Snowflake Cortex `api/v2/cortex/inference:complete` to reject Claude function-calling conversations with HTTP 400 / `code: "390142"` / `message: "Incoming request does not contain a valid payload"` on the turn following a tool result. Symptoms in production traffic: the first turn streams a tool_use call, the SDK fails to execute it, and the second turn either hangs (~80s of empty SSE keepalive frames before the upstream error fires) or returns 390142 immediately.

This PR fixes all three.

## Root causes

### 1. Parameterless tool_use chunks arrive with `input=""` instead of `input={}`

Cortex routes Claude through Bedrock under the hood. For a parameterless tool call (e.g. `get_coordinates()` with no arguments), the streaming chunk arrives as:

```json
{ "type": "tool_use", "name": "get_coordinates", "tool_use_id": "toolu_…", "input": "" }
```

`SnowflakeStreamingHandler.chunk_parser` was passing that empty string through as `function.arguments`. Downstream consumers (the OpenAI Agents SDK, browser-side tool runners) accumulate deltas and then `JSON.parse(arguments)`; `JSON.parse("")` throws `SyntaxError: Unexpected end of JSON input`. The SDK then either errors out or injects a synthetic `tool_result` containing the parse-error message — both of which poison the conversation history that gets replayed to Cortex on the follow-up turn.

### 2. OpenAI `annotations: []` leaks inside content blocks

OpenAI-compatible chat-completion providers emit `annotations: []` on every assistant text block (for parity with the Responses API's citation feature). The field travels back into the conversation history on every follow-up turn. Cortex's `inference:complete` rejects unknown fields inside content blocks with the same `390142` payload error.

The previous `_transform_messages` pass-through branch (`else: transformed_messages.append(msg_to_append)`) propagated the field unchanged.

### 3. Two consecutive assistant messages per tool-using turn

The Agents SDK records a tool-using turn as two separate output items (text first, then tool_call) and replays them as two separate assistant messages on the next request:

```json
{ "role": "assistant", "content": [{ "type": "text", "text": "I'll call the tool.", "annotations": [] }] },
{ "role": "assistant", "content": "", "tool_calls": [ … ] }
```

Cortex (Anthropic-style schema) expects strict role alternation — one assistant message per turn — and rejects consecutive same-role messages. The previous transform produced two separate assistant entries in the request body, one with a plain `content` and one with `content + content_list`.

## Fixes

`litellm/llms/snowflake/chat/transformation.py`:

- **`SnowflakeStreamingHandler.chunk_parser`** — when a `tool_use` delta introduces a `name` with empty or missing `input`, seed `arguments="{}"` so SDK accumulation ends with valid JSON. Dict-valued `input` is serialised to a JSON string. Partial-JSON string continuations (name=null, input='{"loc') pass through unchanged so multi-chunk argument streaming still works. Snowflake-specific delta keys (`type`, `tool_use_id`, `input`, `name`, `content_list`) are stripped after the OpenAI-shaped `tool_calls` field is built.
- **Module helper `_strip_openai_annotations`** — removes `annotations` from each content block of a message; no-op on string / None content.
- **Module helper `_content_to_text_blocks`** — converts an OpenAI-style assistant `content` value (string or list of blocks) into `[{"type": "text", "text": …}]` blocks suitable for inclusion in `content_list`; whitespace-only entries are dropped.
- **`SnowflakeConfig._transform_messages`**:
  - strip annotations on every pass-through message,
  - defensively coerce empty/missing `tool_calls[].function.arguments` to `{}` before JSON-parsing into `tool_use.input`,
  - when an assistant message with `tool_calls` is preceded by a text-only assistant message (no `content_list`, no `tool_calls`), pop the prelude and merge its text into the new message's `content_list` so the request carries one assistant message per turn with `[text_block, tool_use_block]`.

The dual `content: "" + content_list: […]` shape that the previous implementation emits on assistant messages and tool-result user messages is preserved verbatim — Snowflake's public documentation does not specify which of the two should be authoritative on the legacy `inference:complete` endpoint, so the existing shape is left untouched to avoid regressing other working flows.

## Tests

`tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py`:

New `TestSnowflakeCortex390142Fixes` class with 20 tests covering:

- `chunk_parser` empty-args seed: empty string input, missing input key, dict input → JSON string, partial-JSON string continuation passthrough, no-seed when name is absent, Snowflake-specific delta-field cleanup.
- `_strip_openai_annotations`: removes the field from list content; no-op on string / None.
- `_content_to_text_blocks`: string input, list with mixed text / whitespace / non-text blocks, empty inputs.
- `_transform_messages` merge: positive case (text-only assistant + tool_call assistant → merged); no-merge when previous already has `content_list` / `tool_calls`; no-merge across non-assistant role boundaries; annotations stripped on plain (non-merged) assistant; empty / missing / non-empty `tool_calls.arguments` coerced or preserved correctly.
- An end-to-end test that replays the exact failing payload captured from production traffic and asserts the post-transform message list has no consecutive same-role messages, no `annotations` field anywhere, and `tool_use.input` as an object.

Result: 24 existing tests still pass; 20 new tests pass. Total: 44/44.

```
$ pytest tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
======================== 44 passed, 2 warnings in 0.16s ========================
```

## Validation

Reproduced the failing payload locally via `mitmdump` reverse-proxying the LiteLLM container's outbound Snowflake traffic. The captured request body before this PR shows the three symptoms described above and a `400 / 390142` response from Cortex. After applying the patch, `_transform_messages` produces a single assistant message per turn, no `annotations` field anywhere, and `tool_use.input` as `{}` for parameterless calls — matching the schema Cortex accepts.