### PR TITLE
fix(snowflake): flatten array-form message content for Cortex

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -72,6 +72,33 @@ def _content_to_text_blocks(content: Any) -> List[Dict[str, Any]]:
     return []
 
 
+def _content_to_text_string(content: Any) -> str:
+    """
+    Flatten an OpenAI-style `content` value into a plain string.
+
+    Snowflake Cortex `inference:complete` rejects a message whose `content`
+    is an array of content blocks (e.g. `[{"type": "text", "text": "..."}]`)
+    with `390142 Incoming request does not contain a valid payload`; it
+    requires `content` to be a plain string. The OpenAI Agents SDK replays a
+    prior assistant turn with exactly that list-of-blocks shape on every
+    follow-up turn, so a plain multi-turn text conversation (no tools
+    involved) hits 390142 on the second turn. Concatenating the text blocks
+    back into a string is the form Cortex accepts. Non-text blocks are
+    ignored here — tool_use / tool_results are carried in `content_list`.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        )
+    return ""
+
+
 class SnowflakeStreamingHandler(BaseModelResponseIterator):
     """
     Custom streaming handler for Snowflake that handles missing fields in chunk responses.
@@ -392,6 +419,11 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
           Cortex rejects role-alternation violations with 390142.
         - OpenAI `annotations: []` on content blocks -> stripped. Snowflake
           Cortex rejects unknown fields with 390142.
+        - list-form `content` ([{"type": "text", "text": ...}], the shape the
+          Agents SDK replays a prior assistant turn in) -> flattened to a
+          plain string. Snowflake Cortex rejects array-form `content` with
+          390142, so a plain multi-turn text conversation otherwise fails on
+          the second turn.
         - content=None -> content="" (Snowflake requires non-null content)
         """
         transformed_messages: List[Dict[str, Any]] = []
@@ -485,7 +517,9 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
                 transformed_messages.append({
                     "role": "assistant",
-                    "content": msg_dict.get("content") or "",
+                    # Flatten any list-form content to a string — Snowflake
+                    # rejects array-form `content` with 390142.
+                    "content": _content_to_text_string(msg_dict.get("content")),
                     "content_list": content_list,
                 })
 
@@ -497,7 +531,16 @@ class SnowflakeConfig(SnowflakeBaseConfig, OpenAIGPTConfig):
 
                 _strip_openai_annotations(msg_to_append)
 
+                # Snowflake Cortex requires `content` to be a plain string, not
+                # an array of content blocks. The OpenAI Agents SDK replays a
+                # prior assistant turn as list-form content
+                # ([{"type": "text", "text": "..."}]); left unflattened it is
+                # rejected with 390142 on the next turn. Flatten to a string.
                 content_value = msg_to_append.get("content")
+                if isinstance(content_value, list):
+                    msg_to_append["content"] = _content_to_text_string(content_value)
+                    content_value = msg_to_append["content"]
+
                 has_content_list = "content_list" in msg_to_append and msg_to_append.get("content_list")
                 if content_value is None and not has_content_list:
                     msg_to_append["content"] = ""

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -1429,3 +1429,184 @@ class TestSnowflakeCortex390142Fixes:
                     _no_annotations(item)
 
         _no_annotations(transformed)
+
+
+class TestSnowflakeCortexArrayContentFlatten:
+    """
+    Regression coverage for the sc-554963 follow-up: Snowflake Cortex
+    `inference:complete` rejects a message whose `content` is an ARRAY of
+    content blocks (`[{"type": "text", "text": "..."}]`) with
+    `390142 Incoming request does not contain a valid payload`. It requires
+    `content` to be a plain string.
+
+    The OpenAI Agents SDK replays a prior assistant turn with exactly that
+    list-of-blocks shape on every follow-up turn, so a PLAIN multi-turn text
+    conversation (no tools at all) fails on the second turn. This was missed
+    by the original fix because:
+      - the only end-to-end repro covered the tool-call path, never a plain
+        text multi-turn, and
+      - the unit tests exercised list-form content only in the merge path
+        (where it is converted into content_list), never on a standalone
+        assistant message that goes through the passthrough branch.
+
+    Verified against the live Cortex endpoint: array-form content -> HTTP 400
+    / 390142; the same payload flattened to a string -> HTTP 200.
+    """
+
+    def test_helper_flattens_list_to_string(self):
+        from litellm.llms.snowflake.chat.transformation import (
+            _content_to_text_string,
+        )
+
+        assert _content_to_text_string("hello") == "hello"
+        assert _content_to_text_string(None) == ""
+        assert _content_to_text_string([]) == ""
+        assert (
+            _content_to_text_string(
+                [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+            )
+            == "ab"
+        )
+        # non-text blocks are ignored
+        assert (
+            _content_to_text_string(
+                [{"type": "text", "text": "a"}, {"type": "image_url"}]
+            )
+            == "a"
+        )
+
+    def test_standalone_assistant_array_content_flattened_to_string(self):
+        """
+        The exact production-failing shape from the capture:
+        user "Hi" -> assistant replayed with list-form content -> follow-up
+        user message. The assistant content must come out as a string, and
+        the message must NOT acquire a content_list.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "system", "content": "sys"},
+                {"role": "user", "content": "Hi"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Hi! How can I help you with the cell towers map today?",
+                        }
+                    ],
+                },
+                {"role": "user", "content": "Center the map in Cuenca"},
+            ]
+        )
+
+        assistant = transformed[2]
+        assert assistant["role"] == "assistant"
+        assert isinstance(assistant["content"], str)
+        assert (
+            assistant["content"]
+            == "Hi! How can I help you with the cell towers map today?"
+        )
+        # A plain assistant turn must not gain a content_list.
+        assert "content_list" not in assistant
+
+    def test_no_message_has_array_form_content_after_transform(self):
+        """
+        Guard: after transform, NO message may carry list-form `content`
+        (the shape Cortex rejects). Mixes plain text turns and a tool turn.
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "system", "content": [{"type": "text", "text": "sys"}]},
+                {"role": "user", "content": "Hi"},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Hello!"}],
+                },
+                {"role": "user", "content": "do it"},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "calling"}],
+                    "tool_calls": [
+                        {
+                            "id": "t1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+            ]
+        )
+
+        for m in transformed:
+            assert not isinstance(
+                m.get("content"), list
+            ), f"message still has array-form content: {m}"
+
+    def test_tool_call_assistant_array_content_flattened(self):
+        """
+        An assistant message that carries BOTH list-form text content and
+        tool_calls must emit string `content` (the tool_use goes in
+        content_list).
+        """
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "do it"},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "on it"}],
+                    "tool_calls": [
+                        {
+                            "id": "t1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": ""},
+                        }
+                    ],
+                },
+            ]
+        )
+
+        assistant = transformed[-1]
+        assert isinstance(assistant["content"], str)
+        assert assistant["content"] == "on it"
+        assert assistant["content_list"][-1]["type"] == "tool_use"
+        assert assistant["content_list"][-1]["tool_use"]["input"] == {}
+
+    def test_system_message_array_content_flattened(self):
+        """System messages can also arrive with list-form content."""
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "line1 "},
+                        {"type": "text", "text": "line2"},
+                    ],
+                },
+                {"role": "user", "content": "Hi"},
+            ]
+        )
+
+        assert transformed[0]["role"] == "system"
+        assert transformed[0]["content"] == "line1 line2"
+
+    def test_empty_array_content_becomes_empty_string(self):
+        config = SnowflakeConfig()
+
+        transformed = config._transform_messages(
+            [
+                {"role": "user", "content": "Hi"},
+                {"role": "assistant", "content": []},
+            ]
+        )
+
+        assistant = transformed[-1]
+        assert assistant["content"] == ""
+        assert "content_list" not in assistant


### PR DESCRIPTION
## Summary

Snowflake Cortex `api/v2/cortex/inference:complete` rejects a message whose `content` is an **array of content blocks** (e.g. `[{"type": "text", "text": "..."}]`) with:

```json
400 {"code": "390142", "message": "Incoming request does not contain a valid payload."}
```

It requires `content` to be a **plain string**. The transformation in `litellm/llms/snowflake/chat/transformation.py` passed such messages through unchanged, so any conversation that replays a prior assistant turn in list-of-blocks form fails.

## Reproduction

A **plain multi-turn text conversation — no tools involved** triggers it on the second turn:

```
turn 1:  user "Hi"  ->  assistant streams a text answer            ✅ 200
turn 2:  the follow-up request replays the prior assistant turn as
         {"role": "assistant", "content": [{"type": "text", "text": "..."}]}
         user "..."                                                ❌ 400 / 390142
```

The OpenAI Agents SDK (and other consumers that store assistant output as structured content) replays the previous assistant message with `content` as a list of blocks rather than a string, which is what Cortex rejects.

## Verification (live endpoint)

Captured a failing request and replayed it against the real Cortex endpoint two ways:

| Variant | `content` shape | Result |
|---|---|---|
| A — as captured | `[{"type": "text", "text": "..."}]` (array) | **HTTP 400 / 390142** |
| B — flattened | `"..."` (string) | **HTTP 200** |

The only change between A and B is flattening the assistant `content` array to a string.

## Fix

In `_transform_messages`, flatten any list-form `content` into a plain string (concatenating text blocks; non-text blocks are ignored, since `tool_use` / `tool_results` are carried in `content_list`). New helper `_content_to_text_string`. Applied in two places:

- the passthrough branch — system / user / plain assistant messages;
- the assistant branch that also carries `tool_calls` — its own `content` field is flattened (the structured tool call still goes into `content_list`).

## Tests

`tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py` — new `TestSnowflakeCortexArrayContentFlatten` class, 6 tests:

- `_content_to_text_string` helper (string / None / empty / multi-block concat / non-text ignored);
- standalone assistant message with array-form content → flattened to string, no spurious `content_list`;
- guard that **no** message carries array-form `content` after transform (mixed plain-text + tool conversation);
- assistant message with both array-form text content and `tool_calls` → string `content` + `tool_use` in `content_list`;
- system message with array-form content;
- empty array content → empty string.

Result: full suite passes (50/50).

```
$ pytest tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
======================== 50 passed in 0.17s ========================
```