### PR TITLE
chore(ci): register Cortex and Databricks tool-calling features in manifest

### DIFF
--- a/.github/carto-features.yml
+++ b/.github/carto-features.yml
@@ -78,3 +78,45 @@ features:
         file: litellm/responses/litellm_completion_transformation/streaming_iterator.py
       - pattern: "_patch_store_session_in_redis"
         file: litellm/responses/litellm_completion_transformation/transformation.py
+
+  - name: "Snowflake Cortex Claude Function-Calling Follow-up Turns"
+    source_prs: [111]
+    description: "Unblocks multi-turn Claude function-calling on Cortex: rebuilds assistant tool_use content_list, merges consecutive text+tool_call assistant turns, and strips OpenAI-only annotations that Cortex rejects (390142)."
+    files:
+      - litellm/llms/snowflake/chat/transformation.py
+    verification:
+      - pattern: "def _content_to_text_blocks"
+        file: litellm/llms/snowflake/chat/transformation.py
+      - pattern: "def _strip_openai_annotations"
+        file: litellm/llms/snowflake/chat/transformation.py
+      - pattern: "text_prelude_blocks"
+        file: litellm/llms/snowflake/chat/transformation.py
+
+  - name: "Snowflake Cortex Array Content Flattening"
+    source_prs: [112]
+    description: "Flattens OpenAI array-form message content ([{type: text, text: ...}]) to a plain string before sending to Cortex, which rejects array-form content with error 390142."
+    files:
+      - litellm/llms/snowflake/chat/transformation.py
+    verification:
+      - pattern: "def _content_to_text_string"
+        file: litellm/llms/snowflake/chat/transformation.py
+
+  - name: "Databricks Empty Tool Call Arguments Normalization"
+    source_prs: [109, 110]
+    description: "Coerces empty/missing tool_call arguments to '{}' (non-streaming and on the streaming name chunk) so Databricks does not reject parameterless tool calls with INVALID_PARAMETER_VALUE."
+    files:
+      - litellm/llms/databricks/chat/transformation.py
+    verification:
+      - pattern: "def _normalize_empty_tool_call_arguments"
+        file: litellm/llms/databricks/chat/transformation.py
+      - pattern: 'if fn.get("name") and not fn.get("arguments"):'
+        file: litellm/llms/databricks/chat/transformation.py
+
+  - name: "Databricks Strip OpenAI Annotations"
+    source_prs: [110]
+    description: "Removes the OpenAI-only 'annotations' field from outbound Databricks chat content blocks, which Databricks rejects with 'Extra inputs are not permitted'."
+    files:
+      - litellm/llms/databricks/chat/transformation.py
+    verification:
+      - pattern: "def _strip_openai_annotations"
+        file: litellm/llms/databricks/chat/transformation.py


### PR DESCRIPTION
## What

Adds 4 missing entries to `.github/carto-features.yml` so the recently-merged provider tool-calling fixes are protected by the **CARTO Features Manifest Check** workflow against future upstream syncs.

The manifest is a tripwire: each entry stores a `(pattern, file)` fingerprint that CI greps for on every `upstream-sync/**` push and `carto/main` PR. If a sync silently drops a CARTO customization, the missing pattern fails the check.

These features (merged in #109–#112) had no manifest coverage:

| Feature | Source PRs | Verified marker(s) |
|---|---|---|
| Snowflake Cortex Claude function-calling follow-up turns | #111 | `def _content_to_text_blocks`, `def _strip_openai_annotations`, `text_prelude_blocks` |
| Snowflake Cortex array content flattening | #112 | `def _content_to_text_string` |
| Databricks empty tool_call arguments normalization | #109, #110 | `def _normalize_empty_tool_call_arguments`, `if fn.get("name") and not fn.get("arguments"):` |
| Databricks strip OpenAI annotations | #110 | `def _strip_openai_annotations` |

## Verification

Ran the exact CI logic from `carto-features-check.yml` locally — **19/19 patterns verified** (12 existing + 7 new), exit 0.

## Notes

- Manifest-only change. No production code touched.
- `source_prs` / `description` / `files` are documentation; only `verification` drives CI pass/fail.