### PR TITLE
fix(snowflake): assign distinct index per streamed Cortex tool call

### DIFF
--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -119,6 +119,20 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
             if delta.get("type") == "tool_use":
                 name = delta.get("name")
 
+                # Assign a distinct, monotonic index per tool call. Cortex
+                # streams every tool_use block on the single choice (index 0),
+                # so using `choice.index` collapses multiple tool calls onto
+                # one index — the downstream accumulator then concatenates
+                # their names and arguments into a single malformed call
+                # (e.g. `set_layer_style` + `set_map_center_and_zoom_to_layer`).
+                # A new tool call always starts with a name-introducing chunk;
+                # continuation chunks (name=None) stream the arguments and must
+                # keep the current index.
+                tool_call_index = getattr(self, "_tool_call_index", -1)
+                if name:
+                    tool_call_index += 1
+                    self._tool_call_index = tool_call_index
+
                 # Normalize `input` into a JSON string for the OpenAI delta shape.
                 # Cortex routes Claude through Bedrock, which emits parameterless
                 # tool_use chunks with `input=""` instead of `input={}`. The SDK
@@ -143,7 +157,7 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
                         name=name,
                         arguments=arguments,
                     ),
-                    index=choice.get("index", 0),
+                    index=tool_call_index if tool_call_index >= 0 else 0,
                 )
                 delta["tool_calls"] = [tool_call]
                 delta.pop("type", None)

--- a/litellm/llms/snowflake/chat/transformation.py
+++ b/litellm/llms/snowflake/chat/transformation.py
@@ -119,15 +119,8 @@ class SnowflakeStreamingHandler(BaseModelResponseIterator):
             if delta.get("type") == "tool_use":
                 name = delta.get("name")
 
-                # Assign a distinct, monotonic index per tool call. Cortex
-                # streams every tool_use block on the single choice (index 0),
-                # so using `choice.index` collapses multiple tool calls onto
-                # one index — the downstream accumulator then concatenates
-                # their names and arguments into a single malformed call
-                # (e.g. `set_layer_style` + `set_map_center_and_zoom_to_layer`).
-                # A new tool call always starts with a name-introducing chunk;
-                # continuation chunks (name=None) stream the arguments and must
-                # keep the current index.
+                # A new tool call begins on the name-introducing chunk;
+                # continuation chunks (name=None) reuse the current index.
                 tool_call_index = getattr(self, "_tool_call_index", -1)
                 if name:
                     tool_call_index += 1

--- a/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
+++ b/tests/test_litellm/llms/snowflake/chat/test_snowflake_chat_transformation.py
@@ -991,6 +991,50 @@ class TestSnowflakeCortex390142Fixes:
         tc = result.choices[0].delta.tool_calls[0]
         assert tc.function.arguments == ""
 
+    def test_chunk_parser_single_tool_call_starts_at_index_zero(self):
+        handler = self._make_handler()
+
+        result = handler.chunk_parser(self._tool_use_chunk(name="get_coords"))
+
+        assert result.choices[0].delta.tool_calls[0].index == 0
+
+    def test_chunk_parser_assigns_distinct_index_per_tool_call(self):
+        """
+        Cortex streams every tool_use block on the single choice (index 0).
+        Each name-introducing chunk starts a new tool call and must get a
+        distinct, monotonic index; otherwise the downstream accumulator
+        concatenates the names/arguments of separate calls into one
+        malformed tool call (e.g. `set_layer_style` +
+        `set_map_center_and_zoom_to_layer`).
+        """
+        handler = self._make_handler()
+
+        first = handler.chunk_parser(
+            self._tool_use_chunk(name="set_layer_style", input={})
+        )
+        second = handler.chunk_parser(
+            self._tool_use_chunk(name="set_map_center_and_zoom_to_layer", input={})
+        )
+
+        assert first.choices[0].delta.tool_calls[0].index == 0
+        assert second.choices[0].delta.tool_calls[0].index == 1
+
+    def test_chunk_parser_continuation_chunks_keep_current_index(self):
+        """
+        Continuation chunks (name=None, partial JSON arguments) must reuse
+        the index of the tool call whose arguments they are streaming, so
+        the accumulator appends to the right call.
+        """
+        handler = self._make_handler()
+
+        handler.chunk_parser(self._tool_use_chunk(name="first_tool", input=""))
+        cont1 = handler.chunk_parser(self._tool_use_chunk(name=None, input='{"a'))
+        handler.chunk_parser(self._tool_use_chunk(name="second_tool", input=""))
+        cont2 = handler.chunk_parser(self._tool_use_chunk(name=None, input='{"b'))
+
+        assert cont1.choices[0].delta.tool_calls[0].index == 0
+        assert cont2.choices[0].delta.tool_calls[0].index == 1
+
     def test_chunk_parser_strips_snowflake_specific_delta_fields(self):
         handler = self._make_handler()
 


### PR DESCRIPTION
# Description

Shortcut

- Story: https://app.shortcut.com/cartoteam/story/556946/snowflake-cortex-model-unable-to-find-tool
- Autolink: [sc-556946]

Snowflake Cortex (Claude) failed whenever the model requested **two or more tool calls in one streamed turn** — e.g. "create an overlay layer with hotspots" triggering both `set_layer_style` and `set_map_center_and_zoom_to_layer`. The CARTO AI agent surfaced this as:

> Tool `set_layer_styleset_map_center_and_zoom_to_layer` not found in agent AIAgent

along with repeated `Repaired malformed tool call arguments` warnings in the proxy logs.

## Root cause

`SnowflakeStreamingHandler.chunk_parser` assigned every streamed `tool_use` block the **choice index** (`choice.get("index", 0)`), which is always `0`. Cortex streams every tool_use block on that single choice, so all tool calls in a turn arrived at index `0`. Both the real-time client SDK and LiteLLM's `ChunkProcessor` key tool calls by index, so two calls at index `0` were merged: their **names concatenated** (`set_layer_style` + `set_map_center_and_zoom_to_layer`) and their **arguments concatenated** (triggering the JSON repair warning, which then discards one call's arguments).

This only affects Snowflake Cortex (other providers emit a real per-tool-call index) and only when ≥2 tools are requested in one turn.

## Fix

Track a monotonic per-tool-call index that increments on each name-introducing chunk and stays stable across the continuation chunks that stream the arguments. A fresh handler is created per stream, so state is isolated per request.

**Note:** `SnowflakeStreamingHandler` is a CARTO-only customization (tracked in `.github/carto-features.yml`) — the class does not exist in upstream BerriAI/litellm. This fix belongs in our fork only.

## Type of change

- [x] Fix

## Acceptance

1. Configure an agent with Snowflake Cortex Claude (Opus 4.7).
2. Ask it to "Create an overlay layer with hotspots" (a request that calls multiple tools in one turn).
3. The layer is created and styled with **no** "Tool ... not found" error and no "Repaired malformed tool call arguments" warnings.

## Basic checklist

- [x] Good PR name
- [x] Shortcut link
- [x] Just one issue per PR
- [x] Tests (`tests/test_litellm/.../test_snowflake_chat_transformation.py` — 3 new cases for single call, distinct indices, continuation chunks)
