### PR TITLE
fix(ci): build Slack release payload with jq to escape release notes

### DIFF
--- a/.github/workflows/carto-release.yaml
+++ b/.github/workflows/carto-release.yaml
@@ -614,16 +614,11 @@ jobs:
           esac
 
           # Extract key highlights from release notes (first 3 bullet points from Features/Fixes sections)
-          HIGHLIGHTS_TEXT=""
+          FEATURES=""
+          FIXES=""
           if [ -f "release_notes.md" ]; then
             FEATURES=$(grep -A 5 "### ✨" release_notes.md 2>/dev/null | grep "^-" | head -2 | sed 's/^- /• /' || echo "")
             FIXES=$(grep -A 5 "### 🐛" release_notes.md 2>/dev/null | grep "^-" | head -1 | sed 's/^- /• /' || echo "")
-
-            if [ -n "$FEATURES" ] || [ -n "$FIXES" ]; then
-              HIGHLIGHTS_TEXT="\n*Key Highlights:*\n"
-              [ -n "$FEATURES" ] && HIGHLIGHTS_TEXT+="${FEATURES}\n"
-              [ -n "$FIXES" ] && HIGHLIGHTS_TEXT+="${FIXES}"
-            fi
           fi
 
           # Determine color based on release type
@@ -634,61 +629,56 @@ jobs:
             *) RELEASE_COLOR="#808080" ;;
           esac
 
+          # Build the header markdown with real newlines. jq (below) JSON-encodes
+          # them — along with any quotes/backslashes in the release notes — so
+          # arbitrary release-note text can never corrupt the payload.
+          MAIN_TEXT="*${EMOJI} LiteLLM CARTO Release* — \`${RELEASE_TAG}\`"$'\n'"${TYPE_LABEL}"
+          [ -n "$VERSION_CHANGE" ] && MAIN_TEXT+=" (${VERSION_CHANGE})"
+          if [ -n "$FEATURES" ] || [ -n "$FIXES" ]; then
+            MAIN_TEXT+=$'\n'"*Key Highlights:*"
+            [ -n "$FEATURES" ] && MAIN_TEXT+=$'\n'"${FEATURES}"
+            [ -n "$FIXES" ] && MAIN_TEXT+=$'\n'"${FIXES}"
+          fi
+
           echo "[Slack] Sending notification to channel ${SLACK_CHANNEL}"
           echo "::endgroup::"
 
           echo "::group::Posting to Slack"
 
-          # Build Block Kit payload
-          cat > /tmp/slack_payload.json << EOF
-          {
-            "channel": "${SLACK_CHANNEL}",
-            "attachments": [
-              {
-                "color": "${RELEASE_COLOR}",
-                "fallback": "${EMOJI} LiteLLM CARTO Release ${RELEASE_TAG}",
-                "blocks": [
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*${EMOJI} LiteLLM CARTO Release* — \`${RELEASE_TAG}\`\n${TYPE_LABEL}${VERSION_CHANGE:+ ($VERSION_CHANGE)}${HIGHLIGHTS_TEXT}"
-                    }
-                  },
-                  {
-                    "type": "section",
-                    "fields": [
-                      { "type": "mrkdwn", "text": "*CARTO Version:*\n${CARTO_VERSION}" },
-                      { "type": "mrkdwn", "text": "*Upstream Base:*\nv${UPSTREAM_VERSION}" }
-                    ]
-                  },
-                  {
-                    "type": "context",
-                    "elements": [
-                      { "type": "mrkdwn", "text": ":whale: \`${DOCKER_IMAGE}\`" }
-                    ]
-                  },
-                  {
-                    "type": "actions",
-                    "elements": [
-                      {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "View Release", "emoji": true },
-                        "style": "primary",
-                        "url": "${RELEASE_URL}"
-                      },
-                      {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "View Logs", "emoji": true },
-                        "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
+          # Build Block Kit payload with jq so all dynamic values are JSON-escaped
+          jq -n \
+            --arg channel "$SLACK_CHANNEL" \
+            --arg color "$RELEASE_COLOR" \
+            --arg fallback "${EMOJI} LiteLLM CARTO Release ${RELEASE_TAG}" \
+            --arg main_text "$MAIN_TEXT" \
+            --arg carto_version "$CARTO_VERSION" \
+            --arg upstream_version "v${UPSTREAM_VERSION}" \
+            --arg docker_image "$DOCKER_IMAGE" \
+            --arg release_url "$RELEASE_URL" \
+            --arg logs_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            '{
+              channel: $channel,
+              attachments: [
+                {
+                  color: $color,
+                  fallback: $fallback,
+                  blocks: [
+                    { type: "section", text: { type: "mrkdwn", text: $main_text } },
+                    { type: "section", fields: [
+                      { type: "mrkdwn", text: ("*CARTO Version:*\n" + $carto_version) },
+                      { type: "mrkdwn", text: ("*Upstream Base:*\n" + $upstream_version) }
+                    ] },
+                    { type: "context", elements: [
+                      { type: "mrkdwn", text: (":whale: `" + $docker_image + "`") }
+                    ] },
+                    { type: "actions", elements: [
+                      { type: "button", text: { type: "plain_text", text: "View Release", emoji: true }, style: "primary", url: $release_url },
+                      { type: "button", text: { type: "plain_text", text: "View Logs", emoji: true }, url: $logs_url }
+                    ] }
+                  ]
+                }
+              ]
+            }' > /tmp/slack_payload.json
 
           # Validate JSON
           if ! jq empty /tmp/slack_payload.json 2>/dev/null; then


### PR DESCRIPTION
## What

The **Notify Slack of new release** step in `carto-release.yaml` built its JSON payload with a bash heredoc, interpolating release-note text straight into a JSON string. Any release note containing a double quote (or backslash, or the real newlines emitted by the `grep`-based highlight extraction) corrupted the payload — the step's own `jq empty` guard then failed with `Invalid JSON payload` and the job errored.

Seen in [run 27963242265](https://github.com/CartoDB/litellm/actions/runs/27963242265/job/82750212680): the patch release notes contained `"Tool not found"` / `"Repaired malformed tool call arguments"`, which broke the JSON.

## Fix

Rebuild the payload with `jq -n --arg` so every dynamic value is JSON-encoded by jq. The header markdown is assembled with real newlines, which jq encodes as `\n`. Structurally identical output; escape-safe construction.

Verified locally with the exact quote-containing release note from the failing run — `jq empty` passes and newlines/quotes render correctly.

https://claude.ai/code/session_0166ohCp7MoakpyerUTb5svS