### PR TITLE
fix(docker): fetch arm64 prisma schema-engine for non_root image

### DIFF
--- a/docker/Dockerfile.non_root
+++ b/docker/Dockerfile.non_root
@@ -32,7 +32,7 @@ ENV UV_PROJECT_ENVIRONMENT=/app/.venv \
     PATH="/app/.venv/bin:${PATH}" \
     LITELLM_NON_ROOT=true \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x" \
+    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x,linux-arm64-openssl-3.0.x" \
     XDG_CACHE_HOME=/app/.cache
 
 # Copy dependency metadata first for layer caching
@@ -114,7 +114,7 @@ COPY --from=builder /app/docker/supervisord.conf /etc/supervisord.conf
 
 ENV PATH="/app/.venv/bin:${PATH}" \
     PRISMA_BINARY_CACHE_DIR=/app/.cache/prisma-python/binaries \
-    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x" \
+    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x,linux-arm64-openssl-3.0.x" \
     HOME=/app \
     LITELLM_NON_ROOT=true \
     XDG_CACHE_HOME=/app/.cache \


### PR DESCRIPTION
## Problem

The arm64 variant of `litellm-non_root` ships the arm64 **query** engine but **no arm64 schema-engine** — only `schema-engine-debian-openssl-3.0.x` (amd64). As a result, on Apple-Silicon / arm64 hosts `prisma migrate deploy` fails at boot:

```
Error: Could not find schema-engine binary. Searched … schema-engine-linux-arm64-openssl-3.0.x
```

litellm boots (the arm64 query engine connects, so queries run) but the DB is **never migrated** — every `LiteLLM_*` table is missing, and any flow that touches them 401/500s. amd64 (CI, prod) is unaffected, which is why this only bites local arm64 dev.

## Root cause

On the Wolfi base, prisma-client-py's platform detection is **arch-blind**:

```python
# prisma/binaries/platform.py
def binary_platform() -> str:
    distro = linux_distro()           # Wolfi isn't alpine/rhel -> "debian"
    ...
    return f'{distro}-openssl-{ssl}'  # -> "debian-openssl-3.0.x"  (no arm64/amd64!)
```

So the build resolves the schema-engine platform to `debian-openssl-3.0.x` (the amd64 binary) on **both** arches. The query engine escapes this only because `schema.prisma`'s `binaryTargets` includes `"native"`, which resolves the true arch.

## Fix

Name the arm64 target explicitly in `PRISMA_CLI_BINARY_TARGETS` (both build + runtime stages) so the build-time online fetch pulls the arm64 schema-engine alongside the debian one:

```diff
-    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x" \
+    PRISMA_CLI_BINARY_TARGETS="debian-openssl-3.0.x,linux-arm64-openssl-3.0.x" \
```

amd64 is unchanged (debian engine still fetched); the extra arm64 engine on the amd64 image is a few MB of harmless dead weight (could be made arch-aware via `ARG TARGETARCH` if preferred — happy to switch).

## Verification

Built `--target builder --platform linux/arm64` with the change and inspected the image:

```
/app/.cache/.../@prisma/engines/schema-engine-debian-openssl-3.0.x        # amd64 (kept)
/app/.cache/.../@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x   # NEW, arm64
$ schema-engine-linux-arm64-openssl-3.0.x --version
schema-engine-cli ac9d7041…    # execs natively on aarch64
```

With this, the arm64 image self-migrates on boot (`USE_PRISMA_MIGRATE=true`) — no amd64 emulation needed for local dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)