### PR TITLE
fix(rate-limiter-v3): constant hash tag to avoid CROSSSLOT on Redis Cluster

### DIFF
--- a/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
+++ b/litellm/proxy/hooks/dynamic_rate_limiter_v3.py
@@ -245,7 +245,7 @@ class _PROXY_DynamicRateLimitHandlerV3(CustomLogger):
 
             # Query RPM saturation - always read from Redis for multi-node consistency
             if model_group_info.rpm is not None and model_group_info.rpm > 0:
-                # Use v3 limiter's key format: {key:value}:rate_limit_type
+                # Use v3 limiter's key format: {litellm-rl}key:value:rate_limit_type
                 counter_key = self.v3_limiter.create_rate_limit_keys(
                     key="model_saturation_check",
                     value=model,

--- a/litellm/proxy/hooks/parallel_request_limiter_v3.py
+++ b/litellm/proxy/hooks/parallel_request_limiter_v3.py
@@ -284,7 +284,10 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
         """
         Create the rate limit keys for the given key and value.
         """
-        counter_key = f"{{{key}:{value}}}:{rate_limit_type}"
+        # Constant hash tag so every rate-limit key hashes to one Redis Cluster
+        # slot; the batch/increment Lua EVALs stay single-slot and avoid CROSSSLOT
+        # on cluster-mode servers. Do not revert to a per-descriptor tag.
+        counter_key = f"{{litellm-rl}}{key}:{value}:{rate_limit_type}"
 
         return counter_key
 
@@ -480,7 +483,7 @@ class _PROXY_MaxParallelRequestsHandler_v3(CustomLogger):
             max_parallel_requests_limit = rate_limit.get("max_parallel_requests")
             window_size = rate_limit.get("window_size") or self.window_size
 
-            window_key = f"{{{descriptor_key}:{descriptor_value}}}:window"
+            window_key = f"{{litellm-rl}}{descriptor_key}:{descriptor_value}:window"
 
             rate_limit_set = False
             if requests_limit is not None:

--- a/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
+++ b/tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py
@@ -195,8 +195,8 @@ async def test_rate_limiter_script_return_values_v3(monkeypatch, time_controller
     )
 
     # Verify both counter and window values are stored in cache
-    window_key = f"{{api_key:{_api_key}}}:window"
-    counter_key = f"{{api_key:{_api_key}}}:requests"
+    window_key = f"{{litellm-rl}}api_key:{_api_key}:window"
+    counter_key = f"{{litellm-rl}}api_key:{_api_key}:requests"
 
     window_value = await local_cache.async_get_cache(key=window_key)
     counter_value = await local_cache.async_get_cache(key=counter_key)
@@ -561,7 +561,7 @@ async def test_async_log_failure_event_v3():
     # Verify correct operation was created
     assert len(captured_ops) == 1
     op = captured_ops[0]
-    assert op["key"] == f"{{api_key:{_api_key}}}:max_parallel_requests"
+    assert op["key"] == f"{{litellm-rl}}api_key:{_api_key}:max_parallel_requests"
     assert op["increment_value"] == -1
     assert op["ttl"] == 60  # default window size
 
@@ -2394,9 +2394,9 @@ async def test_agent_rate_limit_tpm_increment_on_success(monkeypatch):
     agent_tpm_op = None
     session_tpm_op = None
     for op in captured_operations:
-        if op["key"] == f"{{agent:{_agent_id}}}:tokens":
+        if op["key"] == f"{{litellm-rl}}agent:{_agent_id}:tokens":
             agent_tpm_op = op
-        elif op["key"] == f"{{agent_session:{_agent_id}:{_session_id}}}:tokens":
+        elif op["key"] == f"{{litellm-rl}}agent_session:{_agent_id}:{_session_id}:tokens":
             session_tpm_op = op
 
     assert agent_tpm_op is not None, "Agent TPM increment should be present"


### PR DESCRIPTION
## Problem

The v3 parallel request limiter builds per-descriptor hash-tagged keys (`{api_key:<value>}:requests`, `{team:<value>}:window`, etc.). A single batch/increment Lua `EVAL` in `should_rate_limit` / `_execute_token_increment_script` collects keys for several descriptors, so the `KEYS` array spans multiple hash tags and therefore multiple cluster slots. A plain (non-`RedisCluster`) client against a cluster-mode server surfaces this as `CROSSSLOT Keys in request don't hash to the same slot`. The existing `_group_keys_by_hash_tag` slot-split only runs when a `RedisCluster` client is detected, so a standalone client hits the error.

## Fix

Use one constant hash tag (`{litellm-rl}`) for every rate-limit key instead of a per-descriptor tag, in the two key builders:

- `create_rate_limit_keys` (counter keys)
- `should_rate_limit` (window keys)

All rate-limit keys then hash to a single slot, so each batch/increment `EVAL` is single-slot and no longer hits `CROSSSLOT`, even with a plain client. The descriptor identity moves out of the tag into the key body (`{litellm-rl}api_key:<value>:requests`), so keys stay unique per descriptor and rate-limit semantics are unchanged. No client-mode change, no new dependency.

Tests in `tests/test_litellm/proxy/hooks/test_parallel_request_limiter_v3.py` are updated to the new key format.

## Trade-off

A single constant tag concentrates all rate-limiter state on one slot (one node). That is intended here: on a single-shard cluster the whole keyspace already lives on one node, so there is no loss, and it keeps a plain client free of `CROSSSLOT`. On a genuinely multi-shard cluster this forfeits shard distribution for the rate-limiter workload (hot shard). If distribution across shards is needed later, use a bounded set of N fixed tags (hash the descriptor into one of N) so multi-key EVALs still group by construction.
