### PR TITLE
fix(ci): detect upstream releases without the -stable tag suffix

### DIFF
--- a/.github/workflows/CARTO_UPSTREAM_SYNC.md
+++ b/.github/workflows/CARTO_UPSTREAM_SYNC.md
@@ -10,7 +10,7 @@ CARTO maintains a fork of LiteLLM with custom workflows, documentation, and conf
 flowchart LR
     subgraph Upstream["BerriAI/litellm"]
         U_MAIN[main]
-        U_STABLE[/"v1.X.Y-stable"/]
+        U_STABLE[/"v1.X.Y (latest release)"/]
     end
 
     subgraph CARTO["CartoDB/litellm"]
@@ -286,8 +286,9 @@ gh workflow run carto-upstream-sync-resolver.yml \
 # Current version in production
 grep '^version' pyproject.toml
 
-# Latest upstream stable
-gh release list --repo BerriAI/litellm --limit 10 | grep stable
+# Latest upstream stable (non-prerelease, non-draft)
+gh release list --repo BerriAI/litellm --limit 10 --json tagName,isPrerelease,isDraft \
+  --jq '.[] | select(.isPrerelease == false and .isDraft == false) | .tagName'
 
 # Commits behind upstream
 git fetch origin main carto/main
@@ -301,7 +302,7 @@ If automated resolution fails:
 ```bash
 # 1. Checkout the sync branch
 git fetch origin
-git checkout upstream-sync/v1.X.Y-stable
+git checkout upstream-sync/v1.X.Y
 
 # 2. Start the merge
 git merge origin/carto/main
@@ -311,12 +312,12 @@ git merge origin/carto/main
 
 # 4. Complete the merge
 git add .
-git commit -m "resolve: merge conflicts for v1.X.Y-stable"
+git commit -m "resolve: merge conflicts for v1.X.Y"
 
 # 5. Verify and push
 make lint
 make test-unit
-git push origin upstream-sync/v1.X.Y-stable
+git push origin upstream-sync/v1.X.Y
 ```
 
 ---
@@ -352,10 +353,9 @@ The workflow sends Slack notifications to `#cartodb-ops`:
 
 ### Workflow Not Detecting New Releases
 
-1. Verify release has `-stable` suffix
-2. Check `gh release list --repo BerriAI/litellm`
-3. Ensure version is greater than current (string comparison)
-4. Check workflow logs for jq filter output
+1. Check `gh release list --repo BerriAI/litellm` for the latest non-prerelease, non-draft tag (BerriAI dropped the `-stable` suffix after `v1.83.14-stable`, published 2026-05-02 — releases since are plain `vX.Y.Z` tags)
+2. Ensure version is greater than current (semver comparison via `sort -V`)
+3. Check workflow logs for jq filter output
 
 ### "PR Already Exists" Blocking New Versions
 

--- a/.github/workflows/carto-schema-sync-validator.yml
+++ b/.github/workflows/carto-schema-sync-validator.yml
@@ -47,18 +47,15 @@ jobs:
         run: |
           echo "::group::Detecting target upstream version"
 
-          # Extract version from branch name (upstream-sync/v1.81.0-stable)
+          # Extract version from branch name. carto-upstream-sync-main.yml always names
+          # the branch "upstream-sync/<exact upstream tag>" (e.g. upstream-sync/v1.92.0,
+          # or upstream-sync/v1.83.14-stable for pre-2026-05 syncs) - just strip the prefix.
           BRANCH="${{ github.head_ref }}"
-          VERSION=$(echo "$BRANCH" | sed -n 's/upstream-sync\/v\([0-9.]*\)-stable/v\1.0-stable/p')
+          VERSION=$(echo "$BRANCH" | sed -n 's|^upstream-sync/||p')
 
           if [ -z "$VERSION" ]; then
-            # Try without extra .0
-            VERSION=$(echo "$BRANCH" | sed -n 's/upstream-sync\/\(v[0-9.]*-stable\)/\1/p')
-          fi
-
-          if [ -z "$VERSION" ]; then
-            # Fallback: get latest stable tag
-            VERSION=$(git tag -l "v*-stable" | sort -V | tail -1)
+            # Fallback: latest plain or legacy "-stable" release tag (excludes -rc./-dev. prereleases)
+            VERSION=$(git tag -l | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-stable)?$' | sort -V | tail -1)
             echo "Using fallback version: $VERSION"
           fi
 

--- a/.github/workflows/carto-upstream-sync-main.yml
+++ b/.github/workflows/carto-upstream-sync-main.yml
@@ -14,7 +14,8 @@
 # would bring in unreleased code that may require database tables not in the stable schema.
 #
 # The workflow runs every Monday at noon and performs two checks:
-#   - Detects new stable releases (tagged with -stable suffix) and syncs main
+#   - Detects new stable releases (latest non-prerelease, non-draft GitHub release;
+#     BerriAI dropped the "-stable" tag suffix after v1.83.14-stable) and syncs main
 #   - Creates PR to carto/main if carto/main is behind main (regardless of upstream sync)
 #
 # Uses X_GITHUB_SUPERCARTOFANTE token to allow workflow file modifications.
@@ -48,6 +49,7 @@ jobs:
       has-new-release: ${{ steps.detect-release.outputs.has-new-release }}
       new-version: ${{ steps.detect-release.outputs.new-version }}
       current-version: ${{ steps.detect-release.outputs.current-version }}
+      current-version-tag: ${{ steps.detect-release.outputs.current-version-tag }}
     steps:
       # Checkout carto/main to check what version we currently have in production
       # NOT main (which has unstable upstream dev code that's always ahead of stable)
@@ -78,9 +80,12 @@ jobs:
           CURRENT_VERSION=$(grep -E "^version\s*=" pyproject.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
           echo "[Sync] Current version in carto/main pyproject.toml: ${CURRENT_VERSION}"
 
-          # Get latest stable release tag (ends with -stable, not a prerelease)
+          # Get latest stable release tag (non-prerelease, non-draft).
+          # BerriAI tagged stable releases with a "-stable" suffix through v1.83.14-stable
+          # (2026-05-02); every release since is a plain "vX.Y.Z" tag with isPrerelease=false.
+          # Filtering on isPrerelease/isDraft alone works for both conventions.
           LATEST_STABLE=$(gh release list --repo BerriAI/litellm --limit 50 --json tagName,isPrerelease,isDraft | \
-            jq -r '.[] | select(.isPrerelease == false and .isDraft == false and (.tagName | endswith("-stable"))) | .tagName' | \
+            jq -r '.[] | select(.isPrerelease == false and .isDraft == false) | .tagName' | \
             sort -V | tail -1)
 
           if [[ -z "${LATEST_STABLE}" ]]; then
@@ -107,6 +112,18 @@ jobs:
             echo "has-new-release=true" >> $GITHUB_OUTPUT
             echo "new-version=${LATEST_STABLE}" >> $GITHUB_OUTPUT
             echo "current-version=${CURRENT_VERSION}" >> $GITHUB_OUTPUT
+
+            # Resolve the exact upstream tag for CURRENT_VERSION so compare links work
+            # whether it predates or postdates the "-stable" suffix drop.
+            if git rev-parse "v${CURRENT_VERSION}" >/dev/null 2>&1; then
+              CURRENT_VERSION_TAG="v${CURRENT_VERSION}"
+            elif git rev-parse "v${CURRENT_VERSION}-stable" >/dev/null 2>&1; then
+              CURRENT_VERSION_TAG="v${CURRENT_VERSION}-stable"
+            else
+              CURRENT_VERSION_TAG="v${CURRENT_VERSION}"
+            fi
+            echo "current-version-tag=${CURRENT_VERSION_TAG}" >> $GITHUB_OUTPUT
+
             echo "::notice title=New Release Detected::${LATEST_STABLE} (current: ${CURRENT_VERSION})"
           else
             echo "[Sync] ✅ Already on latest stable: ${CURRENT_VERSION}"
@@ -420,6 +437,7 @@ jobs:
         env:
           NEW_VERSION: ${{ needs.check-new-release.outputs.new-version }}
           CURRENT_VERSION: ${{ needs.check-new-release.outputs.current-version }}
+          CURRENT_VERSION_TAG: ${{ needs.check-new-release.outputs.current-version-tag }}
         run: |
           set -eu
 
@@ -471,7 +489,7 @@ jobs:
           - **Commits Ahead:** ${COMMITS_COUNT}
           - **Files Changed:** ${FILES_CHANGED}
           - **Upstream Repo:** [BerriAI/litellm](https://github.com/BerriAI/litellm)
-          - **Compare Changes:** [v${CURRENT_VERSION}-stable...${NEW_VERSION}](https://github.com/BerriAI/litellm/compare/v${CURRENT_VERSION}-stable...${NEW_VERSION})
+          - **Compare Changes:** [${CURRENT_VERSION_TAG}...${NEW_VERSION}](https://github.com/BerriAI/litellm/compare/${CURRENT_VERSION_TAG}...${NEW_VERSION})
 
           </details>
 
@@ -675,6 +693,7 @@ jobs:
           HAS_NEW_RELEASE: ${{ needs.check-new-release.outputs.has-new-release }}
           NEW_VERSION: ${{ needs.check-new-release.outputs.new-version }}
           CURRENT_VERSION: ${{ needs.check-new-release.outputs.current-version }}
+          CURRENT_VERSION_TAG: ${{ needs.check-new-release.outputs.current-version-tag }}
           NEEDS_SYNC: ${{ needs.check-carto-main-sync.outputs.needs-sync }}
           COMMITS_BEHIND: ${{ needs.check-carto-main-sync.outputs.commits-behind }}
           PR_EXISTS: ${{ needs.check-carto-main-sync.outputs.pr-exists }}
@@ -851,8 +870,8 @@ jobs:
 
           # Build compare URL for viewing changes between versions
           COMPARE_URL=""
-          if [[ -n "${CURRENT_VERSION}" && -n "${NEW_VERSION}" ]]; then
-            COMPARE_URL="https://github.com/BerriAI/litellm/compare/v${CURRENT_VERSION}-stable...${NEW_VERSION}"
+          if [[ -n "${CURRENT_VERSION_TAG}" && -n "${NEW_VERSION}" ]]; then
+            COMPARE_URL="https://github.com/BerriAI/litellm/compare/${CURRENT_VERSION_TAG}...${NEW_VERSION}"
           fi
 
           # Pre-build optional JSON blocks (avoid bash expansion issues in heredoc)


### PR DESCRIPTION
## Summary

The upstream sync pipeline has been silently reporting "up to date" for ~2.5 months while the fork is actually ~40 releases behind.

**Root cause:** BerriAI stopped tagging stable releases with a `-stable` suffix after `v1.83.14-stable` (published 2026-05-02). Every release since is a plain `vX.Y.Z` tag marked `isPrerelease: false` (current latest: `v1.92.0`, 2026-07-12). `carto-upstream-sync-main.yml` and `carto-schema-sync-validator.yml` both filtered releases/tags with `endswith("-stable")`, so nothing has matched since May — the fork's `pyproject.toml` (`1.83.14`) still equals the last tag that filter can find, so the check spuriously passes.

## Changes

- `carto-upstream-sync-main.yml`: drop the `-stable` suffix requirement from release detection — filter on `isPrerelease == false and isDraft == false` alone (works for both the legacy and current tagging convention).
- `carto-upstream-sync-main.yml`: fix compare-URL construction that hardcoded `-stable` onto the *current* version's tag — this would 404 as soon as the fork moves onto a non-suffixed tag. Resolves the exact current-version tag (with or without suffix) via `git rev-parse` and threads it through as a new `current-version-tag` job output.
- `carto-schema-sync-validator.yml`: simplify branch-name version extraction (was two `-stable`-specific sed patterns) to just strip the `upstream-sync/` prefix — matches exactly what `carto-upstream-sync-main.yml` puts there. Fixes the fallback tag lookup similarly.
- `CARTO_UPSTREAM_SYNC.md`: update the runbook/diagram/troubleshooting text that documented the now-obsolete `-stable` requirement.

## Test plan

- [x] YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] All modified `run:` shell blocks pass `bash -n` syntax check
- [ ] Trigger `carto-upstream-sync-main.yml` via `workflow_dispatch` (with `silent: true`) after merge and confirm it detects `v1.92.0` (or whatever is latest by then) as a new release instead of reporting "up to date"
- [ ] Confirm the generated sync PR's compare link and Slack compare link resolve correctly

## Context

Investigated after checking why the weekly sync job kept reporting "already on latest stable" — confirmed via `gh release list --repo BerriAI/litellm` that BerriAI's tagging convention changed and the fork is actually behind.