### PR TITLE
fix(ci): stop gating upstream-sync CI on checks that never run

### DIFF
--- a/.github/workflows/carto-upstream-sync-ci-fixer.yml
+++ b/.github/workflows/carto-upstream-sync-ci-fixer.yml
@@ -6,10 +6,13 @@ name: CARTO Upstream Sync - CI Fixer
 
 on:
   workflow_run:
+    # "LiteLLM Mock Tests" is upstream-deprecated (workflow_dispatch only, no
+    # pull_request trigger) and "LiteLLM Linting" only triggers for PRs against
+    # upstream's own branches (main, litellm_*), never carto/main - so neither
+    # ever completes for these PRs. CARTO's own Docker CI is the only check
+    # that actually runs against upstream-sync/* branches.
     workflows:
-      - "LiteLLM Mock Tests (folder - tests/test_litellm)"
       - "CARTO - Deploy Docker Image (CI)"
-      - "LiteLLM Linting"
     types:
       - completed
     branches:

--- a/.github/workflows/carto-upstream-sync-ready-checker.yml
+++ b/.github/workflows/carto-upstream-sync-ready-checker.yml
@@ -6,10 +6,13 @@ name: CARTO Upstream Sync - Ready Checker
 
 on:
   workflow_run:
+    # "LiteLLM Mock Tests" is upstream-deprecated (workflow_dispatch only, no
+    # pull_request trigger) and "LiteLLM Linting" only triggers for PRs against
+    # upstream's own branches (main, litellm_*), never carto/main - so neither
+    # ever completes for these PRs. CARTO's own Docker CI is the only check
+    # that actually runs against upstream-sync/* branches.
     workflows:
-      - "LiteLLM Mock Tests (folder - tests/test_litellm)"
       - "CARTO - Deploy Docker Image (CI)"
-      - "LiteLLM Linting"
     types:
       - completed
     branches:


### PR DESCRIPTION
## Summary

`carto-upstream-sync-ready-checker.yml` and `carto-upstream-sync-ci-fixer.yml` both listen for `"LiteLLM Mock Tests (folder - tests/test_litellm)"` and `"LiteLLM Linting"` alongside CARTO's own Docker CI. Neither of the first two can ever complete for these PRs:

- `"LiteLLM Mock Tests"` is upstream-deprecated — its `pull_request` trigger is commented out in `test-litellm.yml`, `workflow_dispatch`-only now (manual debugging only).
- `"LiteLLM Linting"` only triggers for PRs against upstream's own branches (`main`, `litellm_internal_staging`, `litellm_oss_branch`, `litellm_**`) — `carto/main` is never in that list, so it never runs against `upstream-sync/*` PRs either.

Only `"CARTO - Deploy Docker Image (CI)"` actually exercises these PRs. Dropped the two dead names from both workflows' `workflow_run` triggers.

Split out from #122 (which is scoped to the separate n8n-notifier image-case bug) to keep review focused.

## Verification

Confirmed via `gh run list --branch upstream-sync/v1.92.0` on PR #121 that neither dead workflow has ever run against a real sync PR, while the Docker CI workflow completes normally.

## Test plan

- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Confirm the next upstream-sync PR gets `sync-ready` added automatically once Docker CI passes