### PR TITLE
fix(gh-workflows): wait long enough for the release image digest to resolve

### DIFF
--- a/.github/workflows/carto-n8n-notifier.yml
+++ b/.github/workflows/carto-n8n-notifier.yml
@@ -353,13 +353,16 @@ jobs:
           # GHCR requires lowercase repo paths; github.repository preserves case (CartoDB/litellm).
           REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
           IMAGE="ghcr.io/${REPO_LOWER}-non_root:${{ github.event.release.tag_name }}"
-          for i in 1 2 3 4 5; do
+          # The docker job below only starts once this release is published and its
+          # multi-arch build+manifest-merge has historically taken 8-12 minutes, so
+          # poll well beyond that instead of the image's typical build time.
+          for i in $(seq 1 40); do
             DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
             if [[ "${DIGEST}" == sha256:* ]]; then
               echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
               exit 0
             fi
-            sleep 15
+            sleep 30
           done
           echo "::error::Could not resolve digest for ${IMAGE}"
           exit 1


### PR DESCRIPTION
## Summary

The n8n release-notify job (`carto-n8n-notifier.yml`, `notify-release`) fires on `release: published`, but the multi-arch docker image for that release tag isn't built yet at that point - `carto-release.yaml`'s `docker` job only starts once `create-release` finishes (needs: create-release), and the build+manifest-merge has taken 8-12 minutes across the last several releases (checked runs from 2026-06-22, 2026-07-15, 2026-08-04). The digest-resolution retry loop only waited ~90 seconds (5 x 15s), so it was guaranteed to time out before the image existed.

Confirmed via https://github.com/CartoDB/litellm/actions/runs/30909471469/job/91992320520 (`v1.92.0-carto.1.19.22`): "Resolve image digest" failed after 90s; the actual `docker / merge` job for that same release run completed ~11 minutes after `create-release`, so the image existed, just not in time for the notifier.

## Fix

Widen the retry loop to 40 attempts x 30s (~20 minutes), comfortably past the observed 8-12 minute build time.

## Test plan

- [ ] Trigger a CARTO release via `workflow_dispatch` and confirm the "Resolve image digest" step succeeds and the n8n webhook fires