### PR TITLE
fix(gh-workflows): exempt upstream-sync PR titles from Conventional Commits gate

### DIFF
--- a/.github/workflows/carto-upstream-sync-main.yml
+++ b/.github/workflows/carto-upstream-sync-main.yml
@@ -588,7 +588,9 @@ jobs:
           PR_BODY_FILE="sync-pr-body.md"
 
           # Build label arguments
-          LABEL_ARGS="--label upstream-sync --label automated"
+          # The PR title ("Upstream Sync: LiteLLM vX.Y.Z") never matches Conventional
+          # Commits, so it must always be exempted from the title-lint gate.
+          LABEL_ARGS="--label upstream-sync --label automated --label ignore-semantic-pull-request"
           if [[ "${SILENT_MODE}" == "true" ]]; then
             LABEL_ARGS="${LABEL_ARGS} --label silent-sync"
             echo "[Sync] Silent mode enabled - adding silent-sync label"


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

PR #128 ("Upstream Sync: LiteLLM v1.95.0") failed the "Validate PR title" check because its auto-generated title has no Conventional Commits prefix. Its predecessor, PR #121, only passed because the `ignore-semantic-pull-request` label was added to it by hand twelve hours after creation:

```
$ gh api repos/CartoDB/litellm/issues/121/timeline --paginate -q '.[] | select(.event=="labeled") | "\(.created_at) \(.actor.login) added \(.label.name)"'
2026-07-13T14:21:56Z Cartofante added upstream-sync
2026-07-13T14:21:57Z Cartofante added automated
2026-07-14T02:34:07Z mateo-di added ignore-semantic-pull-request
```

`carto-upstream-sync-main.yml` never applied that label itself, so every future sync PR would repeat this failure without manual intervention. This PR adds the label to `LABEL_ARGS` at PR-creation time.

Not a testable code path (bash inside a GitHub Actions step); validated by reading `conventional-commits.yml`'s `ignoreLabels` config and PR #121's label history above, and by parsing the edited YAML with `python3 -c "import yaml; yaml.safe_load(...)"`. Applied `ignore-semantic-pull-request` to PR #128 by hand as an immediate unblock; this PR prevents the recurrence.

## Type

🚄 Infrastructure

## Changes

`carto-upstream-sync-main.yml`: always add the `ignore-semantic-pull-request` label when creating an upstream-sync PR, since its title format never matches Conventional Commits.