### PR TITLE
fix(gh-workflows): generate the n8n JWT right before use, not before the digest wait

### DIFF
--- a/.github/workflows/carto-n8n-notifier.yml
+++ b/.github/workflows/carto-n8n-notifier.yml
@@ -132,6 +132,37 @@ jobs:
 
           echo "::endgroup::"
 
+      - name: Log in to GHCR
+        if: steps.pr-info.outputs.is-valid == 'true'
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        if: steps.pr-info.outputs.is-valid == 'true'
+        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
+
+      - name: Resolve image digest
+        if: steps.pr-info.outputs.is-valid == 'true'
+        id: digest
+        run: |
+          set -eu
+          # GHCR requires lowercase repo paths; github.repository preserves case (CartoDB/litellm).
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO_LOWER}-non_root:${{ steps.pr-info.outputs.image-tag }}"
+          for i in 1 2 3 4 5; do
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+            if [[ "${DIGEST}" == sha256:* ]]; then
+              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "::error::Could not resolve digest for ${IMAGE}"
+          exit 1
+
       - name: Generate JWT Token
         if: steps.pr-info.outputs.is-valid == 'true'
         id: jwt
@@ -207,37 +238,6 @@ jobs:
           echo "[Notifier] JWT token generated successfully"
           echo "::endgroup::"
 
-      - name: Log in to GHCR
-        if: steps.pr-info.outputs.is-valid == 'true'
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        if: steps.pr-info.outputs.is-valid == 'true'
-        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
-
-      - name: Resolve image digest
-        if: steps.pr-info.outputs.is-valid == 'true'
-        id: digest
-        run: |
-          set -eu
-          # GHCR requires lowercase repo paths; github.repository preserves case (CartoDB/litellm).
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE="ghcr.io/${REPO_LOWER}-non_root:${{ steps.pr-info.outputs.image-tag }}"
-          for i in 1 2 3 4 5; do
-            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
-            if [[ "${DIGEST}" == sha256:* ]]; then
-              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-            sleep 15
-          done
-          echo "::error::Could not resolve digest for ${IMAGE}"
-          exit 1
-
       - name: Call n8n webhook
         if: steps.pr-info.outputs.is-valid == 'true'
         run: |
@@ -276,6 +276,37 @@ jobs:
     if: github.event_name == 'release'
 
     steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
+
+      - name: Resolve image digest
+        id: digest
+        run: |
+          set -eu
+          # GHCR requires lowercase repo paths; github.repository preserves case (CartoDB/litellm).
+          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE="ghcr.io/${REPO_LOWER}-non_root:${{ github.event.release.tag_name }}"
+          # The docker job below only starts once this release is published and its
+          # multi-arch build+manifest-merge has historically taken 8-12 minutes, so
+          # poll well beyond that instead of the image's typical build time.
+          for i in $(seq 1 40); do
+            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
+            if [[ "${DIGEST}" == sha256:* ]]; then
+              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "::error::Could not resolve digest for ${IMAGE}"
+          exit 1
+
       - name: Generate JWT Token
         id: jwt
         run: |
@@ -335,37 +366,6 @@ jobs:
 
           echo "[Notifier] JWT token generated successfully"
           echo "::endgroup::"
-
-      - name: Log in to GHCR
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@edfb0fe6204400c56fbfd3feba3fe9ad1adfa345
-
-      - name: Resolve image digest
-        id: digest
-        run: |
-          set -eu
-          # GHCR requires lowercase repo paths; github.repository preserves case (CartoDB/litellm).
-          REPO_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          IMAGE="ghcr.io/${REPO_LOWER}-non_root:${{ github.event.release.tag_name }}"
-          # The docker job below only starts once this release is published and its
-          # multi-arch build+manifest-merge has historically taken 8-12 minutes, so
-          # poll well beyond that instead of the image's typical build time.
-          for i in $(seq 1 40); do
-            DIGEST=$(docker buildx imagetools inspect "${IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null || true)
-            if [[ "${DIGEST}" == sha256:* ]]; then
-              echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
-              exit 0
-            fi
-            sleep 30
-          done
-          echo "::error::Could not resolve digest for ${IMAGE}"
-          exit 1
 
       - name: Call n8n webhook for release
         run: |


### PR DESCRIPTION
## Relevant issues

## Linear ticket

## Pre-Submission checklist

**Please complete all items before asking a LiteLLM maintainer to review your PR**

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have requested a Greptile review by commenting `@greptileai` and received a **Confidence Score of at least 4/5** before requesting a maintainer review

## Delays in PR merge?

If you're seeing a delay in your PR being merged, ping the LiteLLM Team on [Slack (#pr-review)](https://join.slack.com/t/litellmossslack/shared_invite/zt-3o7nkuyfr-p_kbNJj8taRfXGgQI1~YyA).

## Screenshots / Proof of Fix

`CARTO - n8n Webhook Notifier` failed on the `v1.92.0-carto.1.19.24` release with a 403 on the webhook call: https://github.com/CartoDB/litellm/actions/runs/31600670056/job/94126971141

```
curl -X POST ... "${{ secrets.N8N_WEBHOOK_URL }}" --fail --silent --show-error
curl: (22) The requested URL returned error: 403
```

Both jobs generate a JWT with a 5 minute expiry (`EXP=$((NOW + 300))`) as their first step, then only use it in their last step, after a `Resolve image digest` step in between that polls `docker buildx imagetools inspect` until the release's multi-arch manifest is pushed. That step's own comment says the wait is "historically taken 8-12 minutes." Pulling the exact timestamps from the failing run confirms it: JWT generated at 13:17:47 (expires 13:22:47), webhook called at 13:27:30, curl got a 403 because the token had been expired for nearly 5 minutes.

This isn't a one-off. `gh run list --repo CartoDB/litellm --workflow carto-n8n-notifier.yml --limit 30` shows the same 403 pattern recurring on `release` events going back to March, and once on a `pull_request` (sync-ready) event, intermittently depending on how long that release's image build happened to take.

## Type

🚄 Infrastructure

## Changes

`carto-n8n-notifier.yml`: in both `notify-upstream-sync-ready` and `notify-release`, move the `Generate JWT Token` step from before the digest-resolution wait to immediately before the webhook call, so the token is always fresh regardless of how long that wait takes. Pure reorder, no step content changed.